### PR TITLE
Fix whetstone sharpening when no target selected

### DIFF
--- a/src/l1j/server/server/clientpackets/C_ItemUSe.java
+++ b/src/l1j/server/server/clientpackets/C_ItemUSe.java
@@ -585,21 +585,30 @@ public class C_ItemUSe extends ClientBasePacket {
 					|| itemId == 49151 || itemId == 49152 || itemId == 49153 || itemId == 49154 || itemId == 49155) {
 				usePolyPotion(pc, itemId);
 				inventory.removeItem(l1iteminstance, 1);
-			} else if (itemId == 40317) {
-				if (l1iteminstance1.getItem().getType2() != 0 && l1iteminstance1.get_durability() > 0) {
-					String msg0;
-					inventory.recoveryDamage(l1iteminstance1);
-					msg0 = l1iteminstance1.getLogName();
-					if (l1iteminstance1.get_durability() == 0) {
-						pc.sendPackets(new S_ServerMessage(464, msg0)); // 'item' is as good as new now.
-					} else {
-						pc.sendPackets(new S_ServerMessage(463, msg0)); // 'item`s' condition got better.
-					}
-				} else {
-					pc.sendPackets(new S_ServerMessage(79)); // Nothing happened.
-				}
-				inventory.removeItem(l1iteminstance, 1);
-			} else if (itemId == 40097 || itemId == 40119 || itemId == 140119 || itemId == 140329) {
+                        } else if (itemId == 40317) {
+                                L1ItemInstance target = l1iteminstance1;
+                                if (target == null || target.getItem().getType2() == 0) {
+                                        target = pc.getWeapon();
+                                }
+
+                                boolean repaired = false;
+                                if (target != null && target.getItem().getType2() != 0 && target.get_durability() > 0) {
+                                        inventory.recoveryDamage(target);
+                                        String msg0 = target.getLogName();
+                                        if (target.get_durability() == 0) {
+                                                pc.sendPackets(new S_ServerMessage(464, msg0)); // 'item' is as good as new now.
+                                        } else {
+                                                pc.sendPackets(new S_ServerMessage(463, msg0)); // 'item`s' condition got better.
+                                        }
+                                        repaired = true;
+                                }
+
+                                if (repaired) {
+                                        inventory.removeItem(l1iteminstance, 1);
+                                } else {
+                                        pc.sendPackets(new S_ServerMessage(79)); // Nothing happened.
+                                }
+                        } else if (itemId == 40097 || itemId == 40119 || itemId == 140119 || itemId == 140329) {
 				for (L1ItemInstance eachItem : inventory.getItems()) {
 					if (eachItem.getItem().getBless() != 2 && eachItem.getItem().getBless() != 130) {
 						continue;


### PR DESCRIPTION
## Summary
- ensure the whetstone selects an equippable target before sharpening
- fall back to the equipped weapon when the selected item is invalid
- guard sharpening from running when no eligible weapon is available
- avoid consuming a whetstone when no durability is restored

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0916b51d48332baf6d397d6ee9a58