### PR TITLE
Add configuration toggle for inventory CHA pet bonus

### DIFF
--- a/config/server.properties
+++ b/config/server.properties
@@ -147,6 +147,10 @@ NpcActiveRange = 21
 # set to -1 for unlimited
 MaxServantSummons = 100
 
+# Controls whether inventory CHA bonuses apply to summon/pet charisma checks.
+# Set to False to ignore charisma bonuses from equipped items when taming.
+inventorycha = True
+
 # Character Hp / Mp ServerSide
 CharacterConfigInServerSide = True
 

--- a/src/l1j/server/Config.java
+++ b/src/l1j/server/Config.java
@@ -600,7 +600,8 @@ public final class Config {
 
 	public static boolean LIMIT_WEAPON_SWITCHING;
 
-	public static int MAX_SERVANT_SUMMONS;
+        public static int MAX_SERVANT_SUMMONS;
+        public static boolean INVENTORY_CHA;
 
 	public static boolean ALT_PET_HUNGER_STATUS_CHANGE;
 
@@ -700,7 +701,8 @@ public final class Config {
 			AUTO_BAN = Boolean.parseBoolean(serverSettings.getProperty("AutoBan", "False"));
 			STOP_DROP = Boolean.parseBoolean(serverSettings.getProperty("StopDrop", "False"));
 			ANIMATION_SPEED = Integer.parseInt(serverSettings.getProperty("DefaultAnimationSpeed", "720"));
-			MAX_SERVANT_SUMMONS = Integer.parseInt(serverSettings.getProperty("MaxServantSummons", "100"));
+                        MAX_SERVANT_SUMMONS = Integer.parseInt(serverSettings.getProperty("MaxServantSummons", "100"));
+                        INVENTORY_CHA = Boolean.parseBoolean(serverSettings.getProperty("inventorycha", "True"));
 
 			REPORT_HOURS_RESET = Integer.parseInt(serverSettings.getProperty("ReportHoursReset", "24"));
 			REPORT_TIME_MINUTES = Integer.parseInt(serverSettings.getProperty("ReportTimeMinutes", "10"));

--- a/src/l1j/server/server/model/Instance/L1PcInstance.java
+++ b/src/l1j/server/server/model/Instance/L1PcInstance.java
@@ -2673,14 +2673,16 @@ public class L1PcInstance extends L1Character {
 		return _inventory;
 	}
 
-	public int getChaForPetControl() {
-		int cha = getCha();
-		L1PcInventory inventory = getInventory();
-		if (inventory != null) {
-			cha += inventory.getInventoryChaBonus();
-		}
-		return cha;
-	}
+        public int getChaForPetControl() {
+                int cha = getCha();
+                if (Config.INVENTORY_CHA) {
+                        L1PcInventory inventory = getInventory();
+                        if (inventory != null) {
+                                cha += inventory.getInventoryChaBonus();
+                        }
+                }
+                return cha;
+        }
 
 	@Override
 	public int getKarma() {


### PR DESCRIPTION
## Summary
- add a new `inventorycha` option to server.properties to control inventory CHA effects on pet charisma checks
- expose the option through `Config.INVENTORY_CHA` and apply it to player pet control calculations

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68e0955324848332aa8747d999daf36e