### PR TITLE
Adjust whetstone usage to repair equipped weapon

### DIFF
--- a/src/l1j/server/server/clientpackets/C_ItemUSe.java
+++ b/src/l1j/server/server/clientpackets/C_ItemUSe.java
@@ -586,24 +586,26 @@ public class C_ItemUSe extends ClientBasePacket {
 				usePolyPotion(pc, itemId);
 				inventory.removeItem(l1iteminstance, 1);
                         } else if (itemId == 40317) {
-                                L1ItemInstance target = l1iteminstance1;
-                                if (target == null || target.getItem().getType2() == 0) {
-                                        target = pc.getWeapon();
-                                }
-                                if (target != null && target.getItem().getType2() != 0 && target.get_durability() > 0) {
-                                        String msg0;
-                                        inventory.recoveryDamage(target);
-                                        msg0 = target.getLogName();
-                                        if (target.get_durability() == 0) {
-                                                pc.sendPackets(new S_ServerMessage(464, msg0)); // 'item' is as good as new now.
-                                        } else {
-                                                pc.sendPackets(new S_ServerMessage(463, msg0)); // 'item`s' condition got better.
-                                        }
+                                L1ItemInstance weapon = pc.getWeapon();
+                                if (weapon == null) {
+                                        pc.sendPackets(new S_SystemMessage("You must equip a weapon to use the whetstone."));
+                                } else if (weapon.get_durability() <= 0) {
+                                        pc.sendPackets(new S_SystemMessage(weapon.getLogName() + " does not need repair."));
                                 } else {
-                                        pc.sendPackets(new S_ServerMessage(79)); // Nothing happened.
+                                        L1ItemInstance repaired = inventory.recoveryDamage(weapon);
+                                        if (repaired != null) {
+                                                String msg0 = weapon.getLogName();
+                                                if (weapon.get_durability() == 0) {
+                                                        pc.sendPackets(new S_ServerMessage(464, msg0)); // 'item' is as good as new now.
+                                                } else {
+                                                        pc.sendPackets(new S_ServerMessage(463, msg0)); // 'item`s' condition got better.
+                                                }
+                                                inventory.removeItem(l1iteminstance, 1);
+                                        } else {
+                                                pc.sendPackets(new S_ServerMessage(79)); // Nothing happened.
+                                        }
                                 }
-                                inventory.removeItem(l1iteminstance, 1);
-			} else if (itemId == 40097 || itemId == 40119 || itemId == 140119 || itemId == 140329) {
+                        } else if (itemId == 40097 || itemId == 40119 || itemId == 140119 || itemId == 140329) {
 				for (L1ItemInstance eachItem : inventory.getItems()) {
 					if (eachItem.getItem().getBless() != 2 && eachItem.getItem().getBless() != 130) {
 						continue;


### PR DESCRIPTION
## Summary
- target the whetstone effect on the player's equipped weapon instead of a clicked item
- prevent whetstone consumption when no weapon is equipped or the weapon has no damage
- only consume the whetstone when the repair succeeds

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e09fadaa44833295bd07008fb3921e