### PR TITLE
Auto-apply whetstone repairs on use

### DIFF
--- a/src/l1j/server/server/clientpackets/C_FixWeaponList.java
+++ b/src/l1j/server/server/clientpackets/C_FixWeaponList.java
@@ -18,6 +18,7 @@
  */
 package l1j.server.server.clientpackets;
 
+import l1j.server.server.model.Instance.L1ItemInstance;
 import l1j.server.server.model.Instance.L1PcInstance;
 import l1j.server.server.network.Client;
 import l1j.server.server.serverpackets.S_FixWeaponList;
@@ -29,11 +30,27 @@ public class C_FixWeaponList extends ClientBasePacket {
 
 	private static final String C_FIX_WEAPON_LIST = "[C] C_FixWeaponList";
 
-	public C_FixWeaponList(byte abyte0[], Client client) {
-		super(abyte0);
-		L1PcInstance pc = client.getActiveChar();
-		pc.sendPackets(new S_FixWeaponList(pc));
-	}
+        public C_FixWeaponList(byte abyte0[], Client client) {
+                super(abyte0);
+                L1PcInstance pc = client.getActiveChar();
+                if (pc == null) {
+                        return;
+                }
+
+                int itemObjId = 0;
+                if (abyte0.length >= 5) {
+                        itemObjId = readD();
+                }
+
+                L1ItemInstance whetstone = pc.getInventory().getItem(itemObjId);
+                if (whetstone != null && whetstone.getItemId() == C_ItemUSe.WHETSTONE_ID) {
+                        if (C_ItemUSe.useWhetstone(pc, whetstone)) {
+                                return;
+                        }
+                }
+
+                pc.sendPackets(new S_FixWeaponList(pc));
+        }
 
 	@Override
 	public String getType() {


### PR DESCRIPTION
## Summary
- share a helper that auto-selects and repairs the first damaged weapon when using a whetstone
- invoke the helper from both C_FixWeaponList and C_ItemUSe so hotkeys and double-clicks perform the repair and keep the item on failure

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0a277ce348332981552c1533a41a4