### PR TITLE
Add Swing map editor tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,21 @@ See the project documentation on the
 [l1j-en project wiki](https://github.com/Sage-BR/L1J4Team/wiki) for general
 project info, the client connector, FAQ, and the setup guide.
 
+## Map editing tool
+
+Designers can edit tile metadata with the Swing-based map editor in
+`tool/map-editor`. Build the server jar first so the tool can reuse the shared
+`L1Map` classes, then launch the editor:
+
+```
+ant jar
+ant -f tool/map-editor/build.xml run
+```
+
+The editor loads `maps/<mapId>.txt` CSV files, provides brush and rectangle
+painting, passability and zone overlays, undo/redo, a minimap preview, and
+exports modified maps back to CSV via `L1Map.toCsv()`.
+
 ## Deployment notes
 
 Before rolling out builds that include HP/MP gain history persistence, apply

--- a/tool/map-editor/README.md
+++ b/tool/map-editor/README.md
@@ -1,0 +1,55 @@
+# L1J Map Editor
+
+The map editor is a Swing-based utility designed to visualize and edit the tile
+CSV files found in `maps/*.txt`. It wraps the same `L1Map` APIs that the server
+uses so designers can tweak tiles, passability and zone data with immediate
+feedback.
+
+## Features
+
+- Load any `maps/<mapId>.txt` file produced by `L1V1Map#toCsv()`.
+- Brush and rectangle painting modes that call `setOriginalTile()` behind the
+  scenes.
+- Per-tile passability toggles backed by `setPassable()`.
+- Zone painting for normal, safety and combat regions using the existing zone
+  bit conventions.
+- Visual overlays that highlight passability and zone data.
+- Palette panel with tool selection, tile ID picker and overlay toggles.
+- Undo/redo history for quick iteration.
+- Coordinate read-out that mirrors `L1Map#toString(Point)`.
+- Live minimap preview that reflects the currently loaded map.
+- Batch export that writes all loaded maps back to CSV using
+  `L1Map.toCsv()`.
+
+## Running the editor
+
+1. Build the server jar (provides the shared `L1Map` classes) from the project
+   root:
+
+   ```sh
+   ant jar
+   ```
+
+2. Launch the editor with the dedicated Ant build file:
+
+   ```sh
+   ant -f tool/map-editor/build.xml run
+   ```
+
+   The task compiles the Swing client and runs `tool.mapeditor.MapEditorApp`.
+
+## Usage overview
+
+- Click **Load Map** and enter a map ID (the filename without `.txt`). The map
+  list tracks every loaded map.
+- Choose a tile ID, zone type and passability state from the palette and paint
+  with either the brush (single-tile, drag-to-paint) or rectangle tool
+  (click-and-drag selection).
+- Toggle the passability/zone overlays to inspect map attributes visually.
+- The minimap panel mirrors the main canvas and updates after each edit.
+- Use **Undo**/**Redo** to walk the edit history for the selected map.
+- **Save Map** writes the currently selected map, while **Export All** writes
+  every loaded map back to `maps/` with the current edits applied.
+
+Maps are stored in-place, so consider keeping version control handy when
+iterating on production data.

--- a/tool/map-editor/build.xml
+++ b/tool/map-editor/build.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="map-editor" default="run" basedir=".">
+    <description>Build script for the Swing-based L1J map editor.</description>
+
+    <property name="src.dir" value="src/main/java" />
+    <property name="build.dir" value="build" />
+    <property name="server.jar" value="../../l1jen.jar" />
+
+    <path id="classpath">
+        <pathelement location="${server.jar}" />
+        <fileset dir="../../lib">
+            <include name="*.jar" />
+        </fileset>
+    </path>
+
+    <target name="clean">
+        <delete dir="${build.dir}" />
+    </target>
+
+    <target name="compile">
+        <mkdir dir="${build.dir}" />
+        <javac srcdir="${src.dir}" destdir="${build.dir}" includeantruntime="false" encoding="UTF-8">
+            <classpath refid="classpath" />
+        </javac>
+    </target>
+
+    <target name="run" depends="compile">
+        <java classname="tool.mapeditor.MapEditorApp" fork="true">
+            <classpath>
+                <pathelement path="${build.dir}" />
+                <pathelement location="${server.jar}" />
+                <fileset dir="../../lib">
+                    <include name="*.jar" />
+                </fileset>
+            </classpath>
+        </java>
+    </target>
+</project>

--- a/tool/map-editor/src/main/java/tool/mapeditor/MapEditorApp.java
+++ b/tool/map-editor/src/main/java/tool/mapeditor/MapEditorApp.java
@@ -1,0 +1,12 @@
+package tool.mapeditor;
+
+import javax.swing.SwingUtilities;
+
+public class MapEditorApp {
+    public static void main(String[] args) {
+        SwingUtilities.invokeLater(() -> {
+            MapEditorFrame frame = new MapEditorFrame();
+            frame.setVisible(true);
+        });
+    }
+}

--- a/tool/map-editor/src/main/java/tool/mapeditor/MapEditorFrame.java
+++ b/tool/map-editor/src/main/java/tool/mapeditor/MapEditorFrame.java
@@ -1,0 +1,294 @@
+package tool.mapeditor;
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.event.ActionEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import javax.swing.DefaultListModel;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JSplitPane;
+import javax.swing.ListSelectionModel;
+import javax.swing.border.EmptyBorder;
+
+import tool.mapeditor.io.CsvMapLoader;
+import tool.mapeditor.io.CsvMapWriter;
+import tool.mapeditor.model.EditableL1Map;
+import tool.mapeditor.model.MapContext;
+import tool.mapeditor.model.ZoneType;
+import tool.mapeditor.ui.MapCanvas;
+import tool.mapeditor.ui.MapCanvas.PaintMode;
+import tool.mapeditor.ui.PalettePanel;
+import tool.mapeditor.ui.MinimapPanel;
+
+public class MapEditorFrame extends JFrame {
+    private final CsvMapLoader loader = CsvMapLoader.forProjectRoot();
+    private final CsvMapWriter writer = CsvMapWriter.forProjectRoot();
+
+    private final Map<Integer, MapContext> contexts = new LinkedHashMap<>();
+    private final DefaultListModel<Integer> mapListModel = new DefaultListModel<>();
+    private final JList<Integer> mapList = new JList<>(mapListModel);
+
+    private final MapCanvas mapCanvas = new MapCanvas();
+    private final PalettePanel palettePanel = new PalettePanel();
+    private final MinimapPanel minimapPanel = new MinimapPanel();
+
+    private final JLabel coordinateLabel = new JLabel("Load a map to begin editing.");
+    private final JLabel statusLabel = new JLabel("Ready");
+
+    private final JButton undoButton = new JButton("Undo");
+    private final JButton redoButton = new JButton("Redo");
+
+    private MapContext activeContext;
+    private boolean paintingInProgress;
+
+    public MapEditorFrame() {
+        super("L1J Map Editor");
+        setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+        setMinimumSize(new Dimension(1200, 800));
+
+        setLayout(new BorderLayout());
+        add(buildLeftPanel(), BorderLayout.WEST);
+        add(buildCenterPanel(), BorderLayout.CENTER);
+        add(buildRightPanel(), BorderLayout.EAST);
+        add(buildStatusBar(), BorderLayout.SOUTH);
+
+        mapCanvas.setPaintListener(request -> {
+            if (activeContext == null) {
+                return;
+            }
+            if (!paintingInProgress) {
+                activeContext.getHistory().snapshot(activeContext.getMap());
+                paintingInProgress = true;
+            }
+            applyPaint(request.startX, request.startY, request.endX, request.endY);
+        });
+        mapCanvas.setHoverListener(point -> updateCoordinateLabel(point.x, point.y));
+        mapCanvas.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseReleased(MouseEvent e) {
+                paintingInProgress = false;
+                updateUndoRedoButtons();
+            }
+        });
+
+        palettePanel.getBrushToggle().addActionListener(e -> mapCanvas.setPaintMode(PaintMode.BRUSH));
+        palettePanel.getRectangleToggle().addActionListener(e -> mapCanvas.setPaintMode(PaintMode.RECTANGLE));
+        palettePanel.getPassabilityOverlayCheck().addActionListener(
+                e -> mapCanvas.setShowPassabilityOverlay(palettePanel.getPassabilityOverlayCheck().isSelected()));
+        palettePanel.getZoneOverlayCheck().addActionListener(
+                e -> mapCanvas.setShowZoneOverlay(palettePanel.getZoneOverlayCheck().isSelected()));
+
+        mapList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        mapList.addListSelectionListener(e -> {
+            if (!e.getValueIsAdjusting()) {
+                Integer mapId = mapList.getSelectedValue();
+                if (mapId != null) {
+                    activateMap(mapId);
+                }
+            }
+        });
+
+        undoButton.addActionListener(this::undoAction);
+        redoButton.addActionListener(this::redoAction);
+
+        pack();
+        setLocationRelativeTo(null);
+        updateUndoRedoButtons();
+    }
+
+    private JPanel buildLeftPanel() {
+        JPanel panel = new JPanel(new BorderLayout());
+        panel.setPreferredSize(new Dimension(320, 800));
+        panel.setBorder(new EmptyBorder(8, 8, 8, 8));
+
+        JPanel buttonRow = new JPanel();
+        JButton loadButton = new JButton("Load Map");
+        loadButton.addActionListener(this::loadMap);
+        JButton saveButton = new JButton("Save Map");
+        saveButton.addActionListener(e -> saveActiveMap());
+        JButton exportButton = new JButton("Export All");
+        exportButton.addActionListener(e -> exportAll());
+        buttonRow.add(loadButton);
+        buttonRow.add(saveButton);
+        buttonRow.add(exportButton);
+        buttonRow.add(undoButton);
+        buttonRow.add(redoButton);
+
+        JScrollPane listScroll = new JScrollPane(mapList);
+        listScroll.setPreferredSize(new Dimension(300, 300));
+
+        JSplitPane splitPane = new JSplitPane(JSplitPane.VERTICAL_SPLIT, listScroll, palettePanel);
+        splitPane.setResizeWeight(0.4);
+        splitPane.setBorder(null);
+
+        panel.add(buttonRow, BorderLayout.NORTH);
+        panel.add(splitPane, BorderLayout.CENTER);
+        return panel;
+    }
+
+    private JPanel buildCenterPanel() {
+        JPanel panel = new JPanel(new BorderLayout());
+        JScrollPane scrollPane = new JScrollPane(mapCanvas);
+        panel.add(scrollPane, BorderLayout.CENTER);
+        return panel;
+    }
+
+    private JPanel buildRightPanel() {
+        JPanel panel = new JPanel(new BorderLayout());
+        panel.setPreferredSize(new Dimension(220, 800));
+        panel.setBorder(new EmptyBorder(8, 8, 8, 8));
+        panel.add(new JLabel("Minimap"), BorderLayout.NORTH);
+        panel.add(minimapPanel, BorderLayout.CENTER);
+        return panel;
+    }
+
+    private JPanel buildStatusBar() {
+        JPanel panel = new JPanel(new BorderLayout());
+        panel.setBorder(new EmptyBorder(4, 8, 4, 8));
+        panel.add(coordinateLabel, BorderLayout.WEST);
+        panel.add(statusLabel, BorderLayout.EAST);
+        return panel;
+    }
+
+    private void loadMap(ActionEvent event) {
+        String input = JOptionPane.showInputDialog(this, "Enter map ID to load", "Load Map",
+                JOptionPane.QUESTION_MESSAGE);
+        if (input == null || input.isBlank()) {
+            return;
+        }
+        try {
+            int mapId = Integer.parseInt(input.trim());
+            EditableL1Map map = loader.load(mapId);
+            MapContext context = new MapContext(map);
+            contexts.put(mapId, context);
+            if (!mapListModel.contains(mapId)) {
+                mapListModel.addElement(mapId);
+            }
+            mapList.setSelectedValue(mapId, true);
+            statusLabel.setText("Loaded map " + mapId);
+        } catch (NumberFormatException ex) {
+            JOptionPane.showMessageDialog(this, "Invalid map ID: " + input, "Error", JOptionPane.ERROR_MESSAGE);
+        } catch (IOException ex) {
+            JOptionPane.showMessageDialog(this, ex.getMessage(), "Load Failed", JOptionPane.ERROR_MESSAGE);
+        }
+    }
+
+    private void activateMap(int mapId) {
+        activeContext = contexts.get(mapId);
+        if (activeContext == null) {
+            return;
+        }
+        mapCanvas.setMap(activeContext.getMap());
+        minimapPanel.setMap(activeContext.getMap());
+        paintingInProgress = false;
+        updateCoordinateLabel(-1, -1);
+        updateUndoRedoButtons();
+    }
+
+    private void applyPaint(int startX, int startY, int endX, int endY) {
+        if (activeContext == null) {
+            return;
+        }
+        EditableL1Map map = activeContext.getMap();
+        ZoneType zone = palettePanel.getSelectedZone();
+        boolean passable = palettePanel.isPassableSelected();
+        int tileId = palettePanel.getSelectedTileId();
+        int worldStartX = map.getX();
+        int worldStartY = map.getY();
+        for (int x = startX; x <= endX; x++) {
+            for (int y = startY; y <= endY; y++) {
+                int worldX = worldStartX + x;
+                int worldY = worldStartY + y;
+                map.setOriginalTile(worldX, worldY, (short) tileId);
+                map.setPassable(worldX, worldY, passable);
+                map.setZone(worldX, worldY, zone);
+            }
+        }
+        minimapPanel.setMap(map);
+        mapCanvas.repaint();
+    }
+
+    private void updateCoordinateLabel(int tileX, int tileY) {
+        if (activeContext == null) {
+            coordinateLabel.setText("No map selected");
+            return;
+        }
+        if (tileX < 0 || tileY < 0) {
+            coordinateLabel.setText("Map " + activeContext.getMap().getId() + ": hover tiles for details");
+            return;
+        }
+        EditableL1Map map = activeContext.getMap();
+        int worldX = map.getX() + tileX;
+        int worldY = map.getY() + tileY;
+        coordinateLabel.setText(map.toString(new l1j.server.server.types.Point(worldX, worldY)));
+    }
+
+    private void saveActiveMap() {
+        if (activeContext == null) {
+            JOptionPane.showMessageDialog(this, "No map selected", "Save Failed", JOptionPane.WARNING_MESSAGE);
+            return;
+        }
+        try {
+            writer.write(activeContext.getMap());
+            statusLabel.setText("Saved map " + activeContext.getMap().getId());
+        } catch (IOException ex) {
+            JOptionPane.showMessageDialog(this, ex.getMessage(), "Save Failed", JOptionPane.ERROR_MESSAGE);
+        }
+    }
+
+    private void exportAll() {
+        int saved = 0;
+        for (MapContext context : contexts.values()) {
+            try {
+                writer.write(context.getMap());
+                saved++;
+            } catch (IOException ex) {
+                JOptionPane.showMessageDialog(this, ex.getMessage(), "Export Failed", JOptionPane.ERROR_MESSAGE);
+                return;
+            }
+        }
+        statusLabel.setText("Exported " + saved + " maps to " + Paths.get("maps").toAbsolutePath());
+    }
+
+    private void undoAction(ActionEvent event) {
+        if (activeContext == null) {
+            return;
+        }
+        activeContext.getHistory().undo(activeContext.getMap());
+        mapCanvas.repaint();
+        minimapPanel.setMap(activeContext.getMap());
+        updateUndoRedoButtons();
+    }
+
+    private void redoAction(ActionEvent event) {
+        if (activeContext == null) {
+            return;
+        }
+        activeContext.getHistory().redo(activeContext.getMap());
+        mapCanvas.repaint();
+        minimapPanel.setMap(activeContext.getMap());
+        updateUndoRedoButtons();
+    }
+
+    private void updateUndoRedoButtons() {
+        if (activeContext == null) {
+            undoButton.setEnabled(false);
+            redoButton.setEnabled(false);
+            return;
+        }
+        undoButton.setEnabled(activeContext.getHistory().canUndo());
+        redoButton.setEnabled(activeContext.getHistory().canRedo());
+    }
+}

--- a/tool/map-editor/src/main/java/tool/mapeditor/io/CsvMapLoader.java
+++ b/tool/map-editor/src/main/java/tool/mapeditor/io/CsvMapLoader.java
@@ -1,0 +1,72 @@
+package tool.mapeditor.io;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import tool.mapeditor.model.EditableL1Map;
+
+/**
+ * Loads map CSV files using the layout produced by {@code L1V1Map#toCsv()}.
+ */
+public class CsvMapLoader {
+    private final Path mapsDirectory;
+
+    public CsvMapLoader(Path mapsDirectory) {
+        this.mapsDirectory = mapsDirectory;
+    }
+
+    public EditableL1Map load(int mapId) throws IOException {
+        Path file = mapsDirectory.resolve(mapId + ".txt");
+        if (!Files.exists(file)) {
+            throw new IOException("Map file not found: " + file.toAbsolutePath());
+        }
+        List<byte[]> rows = new ArrayList<>();
+        int width = -1;
+        try (BufferedReader reader = Files.newBufferedReader(file, StandardCharsets.UTF_8)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                line = line.trim();
+                if (line.isEmpty() || line.startsWith("#")) {
+                    continue;
+                }
+                String[] parts = line.split(",");
+                if (width == -1) {
+                    width = parts.length;
+                }
+                byte[] row = new byte[parts.length];
+                for (int i = 0; i < parts.length; i++) {
+                    row[i] = (byte) Integer.parseInt(parts[i].trim());
+                }
+                rows.add(row);
+            }
+        }
+        if (rows.isEmpty()) {
+            throw new IOException("Map file contains no tile data: " + file.toAbsolutePath());
+        }
+        int height = rows.size();
+        if (width <= 0) {
+            throw new IOException("Map file has invalid width: " + file.toAbsolutePath());
+        }
+        byte[][] tiles = new byte[width][height];
+        for (int y = 0; y < height; y++) {
+            byte[] row = rows.get(y);
+            if (row.length != width) {
+                throw new IOException("Inconsistent row width at line " + (y + 1) + " in " + file.toAbsolutePath());
+            }
+            for (int x = 0; x < width; x++) {
+                tiles[x][y] = row[x];
+            }
+        }
+        return new EditableL1Map(mapId, tiles, 0, 0);
+    }
+
+    public static CsvMapLoader forProjectRoot() {
+        return new CsvMapLoader(Paths.get("maps"));
+    }
+}

--- a/tool/map-editor/src/main/java/tool/mapeditor/io/CsvMapWriter.java
+++ b/tool/map-editor/src/main/java/tool/mapeditor/io/CsvMapWriter.java
@@ -1,0 +1,27 @@
+package tool.mapeditor.io;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import tool.mapeditor.model.EditableL1Map;
+
+public class CsvMapWriter {
+    private final Path mapsDirectory;
+
+    public CsvMapWriter(Path mapsDirectory) {
+        this.mapsDirectory = mapsDirectory;
+    }
+
+    public void write(EditableL1Map map) throws IOException {
+        Path file = mapsDirectory.resolve(map.getId() + ".txt");
+        Files.createDirectories(file.getParent());
+        Files.writeString(file, map.toCsv(), StandardCharsets.UTF_8);
+    }
+
+    public static CsvMapWriter forProjectRoot() {
+        return new CsvMapWriter(Paths.get("maps"));
+    }
+}

--- a/tool/map-editor/src/main/java/tool/mapeditor/model/EditableL1Map.java
+++ b/tool/map-editor/src/main/java/tool/mapeditor/model/EditableL1Map.java
@@ -1,0 +1,530 @@
+package tool.mapeditor.model;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import l1j.server.server.model.map.L1Map;
+import l1j.server.server.types.Point;
+
+/**
+ * Editable in-memory implementation of {@link L1Map} backed by the CSV layout
+ * produced by {@code L1V1Map#toCsv()}.
+ */
+public class EditableL1Map extends L1Map {
+    private static final byte BITFLAG_IS_IMPASSABLE = (byte) 0x80;
+
+    private final int mapId;
+    private final byte[][] tiles; // [x][y]
+    private final int startX;
+    private final int startY;
+
+    private boolean underwater;
+    private boolean markable;
+    private boolean teleportable;
+    private boolean escapable;
+    private boolean useResurrection;
+    private boolean usePainwand;
+    private boolean enabledDeathPenalty;
+    private boolean takePets;
+    private boolean recallPets;
+    private boolean usableItem;
+    private boolean usableSkill;
+
+    public EditableL1Map(int mapId, byte[][] tiles, int startX, int startY) {
+        this(mapId, tiles, startX, startY, new MapAttributes());
+    }
+
+    public EditableL1Map(int mapId, byte[][] tiles, int startX, int startY, MapAttributes attributes) {
+        this.mapId = mapId;
+        this.tiles = tiles;
+        this.startX = startX;
+        this.startY = startY;
+        this.underwater = attributes.isUnderwater();
+        this.markable = attributes.isMarkable();
+        this.teleportable = attributes.isTeleportable();
+        this.escapable = attributes.isEscapable();
+        this.useResurrection = attributes.isUseResurrection();
+        this.usePainwand = attributes.isUsePainwand();
+        this.enabledDeathPenalty = attributes.isEnabledDeathPenalty();
+        this.takePets = attributes.isTakePets();
+        this.recallPets = attributes.isRecallPets();
+        this.usableItem = attributes.isUsableItem();
+        this.usableSkill = attributes.isUsableSkill();
+    }
+
+    public EditableL1Map copy() {
+        byte[][] clone = copyTiles();
+        MapAttributes attributes = toAttributes();
+        return new EditableL1Map(mapId, clone, startX, startY, attributes);
+    }
+
+    public MapAttributes toAttributes() {
+        return new MapAttributes()
+                .setUnderwater(underwater)
+                .setMarkable(markable)
+                .setTeleportable(teleportable)
+                .setEscapable(escapable)
+                .setUseResurrection(useResurrection)
+                .setUsePainwand(usePainwand)
+                .setEnabledDeathPenalty(enabledDeathPenalty)
+                .setTakePets(takePets)
+                .setRecallPets(recallPets)
+                .setUsableItem(usableItem)
+                .setUsableSkill(usableSkill);
+    }
+
+    public void overwriteTiles(byte[][] source) {
+        for (int x = 0; x < tiles.length; x++) {
+            System.arraycopy(source[x], 0, tiles[x], 0, tiles[x].length);
+        }
+    }
+
+    public byte[][] copyTiles() {
+        byte[][] clone = new byte[tiles.length][];
+        for (int x = 0; x < tiles.length; x++) {
+            clone[x] = Arrays.copyOf(tiles[x], tiles[x].length);
+        }
+        return clone;
+    }
+
+    private int toLocalX(int worldX) {
+        return worldX - startX;
+    }
+
+    private int toLocalY(int worldY) {
+        return worldY - startY;
+    }
+
+    private boolean isWithinLocal(int x, int y) {
+        return x >= 0 && x < tiles.length && y >= 0 && y < tiles[0].length;
+    }
+
+    private int accessTile(int worldX, int worldY) {
+        int x = toLocalX(worldX);
+        int y = toLocalY(worldY);
+        if (!isWithinLocal(x, y)) {
+            return 0;
+        }
+        return tiles[x][y] & 0xFF;
+    }
+
+    private int accessOriginalTile(int worldX, int worldY) {
+        return accessTile(worldX, worldY) & (~BITFLAG_IS_IMPASSABLE & 0xFF);
+    }
+
+    private void setTile(int worldX, int worldY, int value) {
+        int x = toLocalX(worldX);
+        int y = toLocalY(worldY);
+        if (!isWithinLocal(x, y)) {
+            return;
+        }
+        tiles[x][y] = (byte) value;
+    }
+
+    public void setZone(int worldX, int worldY, ZoneType zone) {
+        int tile = accessOriginalTile(worldX, worldY);
+        tile &= ~0x30;
+        if (zone == ZoneType.SAFETY) {
+            tile |= 0x10;
+        } else if (zone == ZoneType.COMBAT) {
+            tile |= 0x20;
+        }
+        setOriginalTile(worldX, worldY, (short) tile);
+    }
+
+    @Override
+    public int getId() {
+        return mapId;
+    }
+
+    @Override
+    public int getX() {
+        return startX;
+    }
+
+    @Override
+    public int getY() {
+        return startY;
+    }
+
+    @Override
+    public int getWidth() {
+        return tiles.length;
+    }
+
+    @Override
+    public int getHeight() {
+        return tiles.length == 0 ? 0 : tiles[0].length;
+    }
+
+    @Override
+    public int getTile(int x, int y) {
+        int tile = accessTile(x, y);
+        if ((tile & BITFLAG_IS_IMPASSABLE) == BITFLAG_IS_IMPASSABLE) {
+            return 300;
+        }
+        return accessOriginalTile(x, y);
+    }
+
+    @Override
+    public int getOriginalTile(int x, int y) {
+        return accessOriginalTile(x, y);
+    }
+
+    @Override
+    public void setOriginalTile(int x, int y, short value) {
+        int original = value & 0xFF;
+        boolean wasImpassable = isImpassable(x, y);
+        setTile(x, y, original);
+        setPassable(x, y, !wasImpassable);
+    }
+
+    @Override
+    public boolean isInMap(Point pt) {
+        return isInMap(pt.getX(), pt.getY());
+    }
+
+    @Override
+    public boolean isInMap(int x, int y) {
+        int localX = toLocalX(x);
+        int localY = toLocalY(y);
+        return isWithinLocal(localX, localY);
+    }
+
+    @Override
+    public boolean isPassable(Point pt) {
+        return isPassable(pt.getX(), pt.getY());
+    }
+
+    @Override
+    public boolean isPassable(int x, int y) {
+        return isPassable(x, y - 1, 4) || isPassable(x + 1, y, 6) || isPassable(x, y + 1, 0)
+                || isPassable(x - 1, y, 2);
+    }
+
+    @Override
+    public boolean isPassable(Point pt, int heading) {
+        return isPassable(pt.getX(), pt.getY(), heading);
+    }
+
+    @Override
+    public boolean isPassable(int x, int y, int heading) {
+        int tile1 = accessTile(x, y);
+        int tile2;
+
+        if (heading == 0) {
+            tile2 = accessTile(x, y - 1);
+        } else if (heading == 1) {
+            tile2 = accessTile(x + 1, y - 1);
+        } else if (heading == 2) {
+            tile2 = accessTile(x + 1, y);
+        } else if (heading == 3) {
+            tile2 = accessTile(x + 1, y + 1);
+        } else if (heading == 4) {
+            tile2 = accessTile(x, y + 1);
+        } else if (heading == 5) {
+            tile2 = accessTile(x - 1, y + 1);
+        } else if (heading == 6) {
+            tile2 = accessTile(x - 1, y);
+        } else if (heading == 7) {
+            tile2 = accessTile(x - 1, y - 1);
+        } else {
+            return false;
+        }
+
+        if ((tile2 & BITFLAG_IS_IMPASSABLE) == BITFLAG_IS_IMPASSABLE) {
+            return false;
+        }
+
+        if (heading == 0) {
+            return (tile1 & 0x02) == 0x02;
+        } else if (heading == 1) {
+            int tile3 = accessTile(x, y - 1);
+            int tile4 = accessTile(x + 1, y);
+            return (tile3 & 0x01) == 0x01 || (tile4 & 0x02) == 0x02;
+        } else if (heading == 2) {
+            return (tile1 & 0x01) == 0x01;
+        } else if (heading == 3) {
+            int tile3 = accessTile(x, y + 1);
+            return (tile3 & 0x01) == 0x01;
+        } else if (heading == 4) {
+            return (tile2 & 0x02) == 0x02;
+        } else if (heading == 5) {
+            return (tile2 & 0x01) == 0x01 || (tile2 & 0x02) == 0x02;
+        } else if (heading == 6) {
+            return (tile2 & 0x01) == 0x01;
+        } else if (heading == 7) {
+            int tile3 = accessTile(x - 1, y);
+            return (tile3 & 0x02) == 0x02;
+        }
+
+        return false;
+    }
+
+    @Override
+    public void setPassable(Point pt, boolean isPassable) {
+        setPassable(pt.getX(), pt.getY(), isPassable);
+    }
+
+    @Override
+    public void setPassable(int x, int y, boolean isPassable) {
+        int tile = accessTile(x, y);
+        if (isPassable) {
+            tile &= ~BITFLAG_IS_IMPASSABLE;
+        } else {
+            tile |= BITFLAG_IS_IMPASSABLE;
+        }
+        setTile(x, y, tile);
+    }
+
+    @Override
+    public boolean isSafetyZone(Point pt) {
+        return isSafetyZone(pt.getX(), pt.getY());
+    }
+
+    @Override
+    public boolean isSafetyZone(int x, int y) {
+        int tile = accessOriginalTile(x, y);
+        return (tile & 0x30) == 0x10;
+    }
+
+    @Override
+    public boolean isCombatZone(Point pt) {
+        return isCombatZone(pt.getX(), pt.getY());
+    }
+
+    @Override
+    public boolean isCombatZone(int x, int y) {
+        int tile = accessOriginalTile(x, y);
+        return (tile & 0x30) == 0x20;
+    }
+
+    @Override
+    public boolean isNormalZone(Point pt) {
+        return isNormalZone(pt.getX(), pt.getY());
+    }
+
+    @Override
+    public boolean isNormalZone(int x, int y) {
+        int tile = accessOriginalTile(x, y);
+        return (tile & 0x30) == 0x00;
+    }
+
+    @Override
+    public boolean isArrowPassable(Point pt) {
+        return isArrowPassable(pt.getX(), pt.getY());
+    }
+
+    @Override
+    public boolean isArrowPassable(int x, int y) {
+        return isArrowPassable(x, y - 1, 4) || isArrowPassable(x + 1, y, 6) || isArrowPassable(x, y + 1, 0)
+                || isArrowPassable(x - 1, y, 2);
+    }
+
+    @Override
+    public boolean isArrowPassable(Point pt, int heading) {
+        return isArrowPassable(pt.getX(), pt.getY(), heading);
+    }
+
+    @Override
+    public boolean isArrowPassable(int x, int y, int heading) {
+        int tile1 = accessTile(x, y);
+        int tile2;
+
+        if (heading == 0) {
+            tile2 = accessTile(x, y - 1);
+        } else if (heading == 1) {
+            tile2 = accessTile(x + 1, y - 1);
+        } else if (heading == 2) {
+            tile2 = accessTile(x + 1, y);
+        } else if (heading == 3) {
+            tile2 = accessTile(x + 1, y + 1);
+        } else if (heading == 4) {
+            tile2 = accessTile(x, y + 1);
+        } else if (heading == 5) {
+            tile2 = accessTile(x - 1, y + 1);
+        } else if (heading == 6) {
+            tile2 = accessTile(x - 1, y);
+        } else if (heading == 7) {
+            tile2 = accessTile(x - 1, y - 1);
+        } else {
+            return false;
+        }
+
+        if ((tile2 & BITFLAG_IS_IMPASSABLE) == BITFLAG_IS_IMPASSABLE) {
+            return false;
+        }
+
+        if (heading == 0) {
+            return (tile1 & 0x02) == 0x02;
+        } else if (heading == 1) {
+            int tile3 = accessTile(x, y - 1);
+            int tile4 = accessTile(x + 1, y);
+            return (tile3 & 0x01) == 0x01 || (tile4 & 0x02) == 0x02;
+        } else if (heading == 2) {
+            return (tile1 & 0x01) == 0x01;
+        } else if (heading == 3) {
+            int tile3 = accessTile(x, y + 1);
+            return (tile3 & 0x01) == 0x01;
+        } else if (heading == 4) {
+            return (tile2 & 0x02) == 0x02;
+        } else if (heading == 5) {
+            return (tile2 & 0x01) == 0x01 || (tile2 & 0x02) == 0x02;
+        } else if (heading == 6) {
+            return (tile2 & 0x01) == 0x01;
+        } else if (heading == 7) {
+            int tile3 = accessTile(x - 1, y);
+            return (tile3 & 0x02) == 0x02;
+        }
+
+        return false;
+    }
+
+    @Override
+    public boolean isUnderwater() {
+        return underwater;
+    }
+
+    public void setUnderwater(boolean underwater) {
+        this.underwater = underwater;
+    }
+
+    @Override
+    public boolean isMarkable() {
+        return markable;
+    }
+
+    public void setMarkable(boolean markable) {
+        this.markable = markable;
+    }
+
+    @Override
+    public boolean isTeleportable() {
+        return teleportable;
+    }
+
+    public void setTeleportable(boolean teleportable) {
+        this.teleportable = teleportable;
+    }
+
+    @Override
+    public boolean isEscapable() {
+        return escapable;
+    }
+
+    public void setEscapable(boolean escapable) {
+        this.escapable = escapable;
+    }
+
+    @Override
+    public boolean isUseResurrection() {
+        return useResurrection;
+    }
+
+    public void setUseResurrection(boolean useResurrection) {
+        this.useResurrection = useResurrection;
+    }
+
+    @Override
+    public boolean isUsePainwand() {
+        return usePainwand;
+    }
+
+    public void setUsePainwand(boolean usePainwand) {
+        this.usePainwand = usePainwand;
+    }
+
+    @Override
+    public boolean isEnabledDeathPenalty() {
+        return enabledDeathPenalty;
+    }
+
+    public void setEnabledDeathPenalty(boolean enabledDeathPenalty) {
+        this.enabledDeathPenalty = enabledDeathPenalty;
+    }
+
+    @Override
+    public boolean isTakePets() {
+        return takePets;
+    }
+
+    public void setTakePets(boolean takePets) {
+        this.takePets = takePets;
+    }
+
+    @Override
+    public boolean isRecallPets() {
+        return recallPets;
+    }
+
+    public void setRecallPets(boolean recallPets) {
+        this.recallPets = recallPets;
+    }
+
+    @Override
+    public boolean isUsableItem() {
+        return usableItem;
+    }
+
+    public void setUsableItem(boolean usableItem) {
+        this.usableItem = usableItem;
+    }
+
+    @Override
+    public boolean isUsableSkill() {
+        return usableSkill;
+    }
+
+    public void setUsableSkill(boolean usableSkill) {
+        this.usableSkill = usableSkill;
+    }
+
+    @Override
+    public boolean isFishingZone(int x, int y) {
+        return accessOriginalTile(x, y) == 16;
+    }
+
+    @Override
+    public String toCsv() throws IOException {
+        StringBuilder builder = new StringBuilder();
+        int width = getWidth();
+        int height = getHeight();
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                builder.append(tiles[x][y] & 0xFF);
+                if (x < width - 1) {
+                    builder.append(',');
+                }
+            }
+            builder.append('\n');
+        }
+        return builder.toString();
+    }
+
+    @Override
+    public String toString(Point pt) {
+        int x = pt.getX();
+        int y = pt.getY();
+        StringBuilder sb = new StringBuilder();
+        sb.append("(x=").append(x).append(", y=").append(y).append(") ");
+        sb.append("tile=").append(getOriginalTile(x, y));
+        sb.append(", passable=").append(isPassable(x, y));
+        if (isSafetyZone(x, y)) {
+            sb.append(", safety zone");
+        } else if (isCombatZone(x, y)) {
+            sb.append(", combat zone");
+        } else {
+            sb.append(", normal zone");
+        }
+        return sb.toString();
+    }
+
+    public byte getRawTile(int worldX, int worldY) {
+        return tiles[toLocalX(worldX)][toLocalY(worldY)];
+    }
+
+    public boolean isImpassable(int worldX, int worldY) {
+        int tile = accessTile(worldX, worldY);
+        return (tile & BITFLAG_IS_IMPASSABLE) == BITFLAG_IS_IMPASSABLE;
+    }
+}

--- a/tool/map-editor/src/main/java/tool/mapeditor/model/MapAttributes.java
+++ b/tool/map-editor/src/main/java/tool/mapeditor/model/MapAttributes.java
@@ -1,0 +1,117 @@
+package tool.mapeditor.model;
+
+/**
+ * Container for per-map attribute toggles that are exposed through {@link EditableL1Map}.
+ */
+public class MapAttributes {
+    private boolean underwater;
+    private boolean markable;
+    private boolean teleportable;
+    private boolean escapable;
+    private boolean useResurrection;
+    private boolean usePainwand;
+    private boolean enabledDeathPenalty;
+    private boolean takePets;
+    private boolean recallPets;
+    private boolean usableItem;
+    private boolean usableSkill;
+
+    public boolean isUnderwater() {
+        return underwater;
+    }
+
+    public MapAttributes setUnderwater(boolean underwater) {
+        this.underwater = underwater;
+        return this;
+    }
+
+    public boolean isMarkable() {
+        return markable;
+    }
+
+    public MapAttributes setMarkable(boolean markable) {
+        this.markable = markable;
+        return this;
+    }
+
+    public boolean isTeleportable() {
+        return teleportable;
+    }
+
+    public MapAttributes setTeleportable(boolean teleportable) {
+        this.teleportable = teleportable;
+        return this;
+    }
+
+    public boolean isEscapable() {
+        return escapable;
+    }
+
+    public MapAttributes setEscapable(boolean escapable) {
+        this.escapable = escapable;
+        return this;
+    }
+
+    public boolean isUseResurrection() {
+        return useResurrection;
+    }
+
+    public MapAttributes setUseResurrection(boolean useResurrection) {
+        this.useResurrection = useResurrection;
+        return this;
+    }
+
+    public boolean isUsePainwand() {
+        return usePainwand;
+    }
+
+    public MapAttributes setUsePainwand(boolean usePainwand) {
+        this.usePainwand = usePainwand;
+        return this;
+    }
+
+    public boolean isEnabledDeathPenalty() {
+        return enabledDeathPenalty;
+    }
+
+    public MapAttributes setEnabledDeathPenalty(boolean enabledDeathPenalty) {
+        this.enabledDeathPenalty = enabledDeathPenalty;
+        return this;
+    }
+
+    public boolean isTakePets() {
+        return takePets;
+    }
+
+    public MapAttributes setTakePets(boolean takePets) {
+        this.takePets = takePets;
+        return this;
+    }
+
+    public boolean isRecallPets() {
+        return recallPets;
+    }
+
+    public MapAttributes setRecallPets(boolean recallPets) {
+        this.recallPets = recallPets;
+        return this;
+    }
+
+    public boolean isUsableItem() {
+        return usableItem;
+    }
+
+    public MapAttributes setUsableItem(boolean usableItem) {
+        this.usableItem = usableItem;
+        return this;
+    }
+
+    public boolean isUsableSkill() {
+        return usableSkill;
+    }
+
+    public MapAttributes setUsableSkill(boolean usableSkill) {
+        this.usableSkill = usableSkill;
+        return this;
+    }
+}

--- a/tool/map-editor/src/main/java/tool/mapeditor/model/MapContext.java
+++ b/tool/map-editor/src/main/java/tool/mapeditor/model/MapContext.java
@@ -1,0 +1,18 @@
+package tool.mapeditor.model;
+
+public class MapContext {
+    private final EditableL1Map map;
+    private final MapHistory history = new MapHistory();
+
+    public MapContext(EditableL1Map map) {
+        this.map = map;
+    }
+
+    public EditableL1Map getMap() {
+        return map;
+    }
+
+    public MapHistory getHistory() {
+        return history;
+    }
+}

--- a/tool/map-editor/src/main/java/tool/mapeditor/model/MapHistory.java
+++ b/tool/map-editor/src/main/java/tool/mapeditor/model/MapHistory.java
@@ -1,0 +1,48 @@
+package tool.mapeditor.model;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ * Simple undo/redo stack for {@link EditableL1Map} instances.
+ */
+public class MapHistory {
+    private final Deque<byte[][]> undoStack = new ArrayDeque<>();
+    private final Deque<byte[][]> redoStack = new ArrayDeque<>();
+
+    public void snapshot(EditableL1Map map) {
+        undoStack.push(map.copyTiles());
+        redoStack.clear();
+    }
+
+    public boolean canUndo() {
+        return !undoStack.isEmpty();
+    }
+
+    public boolean canRedo() {
+        return !redoStack.isEmpty();
+    }
+
+    public void undo(EditableL1Map map) {
+        if (!canUndo()) {
+            return;
+        }
+        redoStack.push(map.copyTiles());
+        byte[][] previous = undoStack.pop();
+        map.overwriteTiles(previous);
+    }
+
+    public void redo(EditableL1Map map) {
+        if (!canRedo()) {
+            return;
+        }
+        undoStack.push(map.copyTiles());
+        byte[][] next = redoStack.pop();
+        map.overwriteTiles(next);
+    }
+
+    public void clear() {
+        undoStack.clear();
+        redoStack.clear();
+    }
+}

--- a/tool/map-editor/src/main/java/tool/mapeditor/model/ZoneType.java
+++ b/tool/map-editor/src/main/java/tool/mapeditor/model/ZoneType.java
@@ -1,0 +1,7 @@
+package tool.mapeditor.model;
+
+public enum ZoneType {
+    NORMAL,
+    SAFETY,
+    COMBAT
+}

--- a/tool/map-editor/src/main/java/tool/mapeditor/ui/MapCanvas.java
+++ b/tool/map-editor/src/main/java/tool/mapeditor/ui/MapCanvas.java
@@ -1,0 +1,279 @@
+package tool.mapeditor.ui;
+
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.RenderingHints;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.function.Consumer;
+
+import javax.swing.JPanel;
+
+import tool.mapeditor.model.EditableL1Map;
+
+public class MapCanvas extends JPanel {
+    public enum PaintMode {
+        BRUSH,
+        RECTANGLE
+    }
+
+    public static class PaintRequest {
+        public final int startX;
+        public final int startY;
+        public final int endX;
+        public final int endY;
+
+        public PaintRequest(int startX, int startY, int endX, int endY) {
+            this.startX = Math.min(startX, endX);
+            this.startY = Math.min(startY, endY);
+            this.endX = Math.max(startX, endX);
+            this.endY = Math.max(startY, endY);
+        }
+    }
+
+    private EditableL1Map map;
+    private int tileSize = 16;
+    private PaintMode paintMode = PaintMode.BRUSH;
+    private Consumer<PaintRequest> paintListener;
+    private Consumer<Point> hoverListener;
+    private boolean showPassabilityOverlay = true;
+    private boolean showZoneOverlay = false;
+
+    private Point dragStart;
+    private Point hoverTile;
+    private Rectangle previewRectangle;
+
+    public MapCanvas() {
+        setBackground(Color.DARK_GRAY);
+        MouseAdapter adapter = new MouseAdapter() {
+            @Override
+            public void mousePressed(MouseEvent e) {
+                if (map == null) {
+                    return;
+                }
+                int tileX = clampTile(e.getX() / tileSize, map.getWidth());
+                int tileY = clampTile(e.getY() / tileSize, map.getHeight());
+                dragStart = new Point(tileX, tileY);
+                if (paintMode == PaintMode.BRUSH) {
+                    firePaint(new PaintRequest(tileX, tileY, tileX, tileY));
+                }
+            }
+
+            @Override
+            public void mouseDragged(MouseEvent e) {
+                if (map == null) {
+                    return;
+                }
+                int tileX = clampTile(e.getX() / tileSize, map.getWidth());
+                int tileY = clampTile(e.getY() / tileSize, map.getHeight());
+                hoverTile = new Point(tileX, tileY);
+                notifyHover(tileX, tileY);
+                if (paintMode == PaintMode.BRUSH && dragStart != null) {
+                    firePaint(new PaintRequest(tileX, tileY, tileX, tileY));
+                } else if (paintMode == PaintMode.RECTANGLE && dragStart != null) {
+                    previewRectangle = createRectangle(dragStart.x, dragStart.y, tileX, tileY);
+                    repaint();
+                }
+            }
+
+            @Override
+            public void mouseReleased(MouseEvent e) {
+                if (map == null || dragStart == null) {
+                    return;
+                }
+                int tileX = clampTile(e.getX() / tileSize, map.getWidth());
+                int tileY = clampTile(e.getY() / tileSize, map.getHeight());
+                if (paintMode == PaintMode.RECTANGLE) {
+                    firePaint(new PaintRequest(dragStart.x, dragStart.y, tileX, tileY));
+                }
+                dragStart = null;
+                previewRectangle = null;
+                repaint();
+            }
+
+            @Override
+            public void mouseMoved(MouseEvent e) {
+                if (map == null) {
+                    return;
+                }
+                int tileX = clampTile(e.getX() / tileSize, map.getWidth());
+                int tileY = clampTile(e.getY() / tileSize, map.getHeight());
+                hoverTile = new Point(tileX, tileY);
+                notifyHover(tileX, tileY);
+                repaint();
+            }
+        };
+        addMouseListener(adapter);
+        addMouseMotionListener(adapter);
+    }
+
+    private void notifyHover(int tileX, int tileY) {
+        if (hoverListener != null) {
+            hoverListener.accept(new Point(tileX, tileY));
+        }
+    }
+
+    private Rectangle createRectangle(int x1, int y1, int x2, int y2) {
+        int startX = Math.min(x1, x2);
+        int startY = Math.min(y1, y2);
+        int width = Math.abs(x1 - x2) + 1;
+        int height = Math.abs(y1 - y2) + 1;
+        return new Rectangle(startX, startY, width, height);
+    }
+
+    private int clampTile(int value, int max) {
+        if (max <= 0) {
+            return 0;
+        }
+        if (value < 0) {
+            return 0;
+        }
+        if (value >= max) {
+            return max - 1;
+        }
+        return value;
+    }
+
+    private void firePaint(PaintRequest request) {
+        if (paintListener != null) {
+            paintListener.accept(request);
+        }
+    }
+
+    public void setMap(EditableL1Map map) {
+        this.map = map;
+        this.dragStart = null;
+        this.previewRectangle = null;
+        this.hoverTile = null;
+        updatePreferredSize();
+        repaint();
+    }
+
+    public EditableL1Map getMap() {
+        return map;
+    }
+
+    public void setPaintMode(PaintMode mode) {
+        this.paintMode = mode;
+    }
+
+    public void setTileSize(int tileSize) {
+        this.tileSize = tileSize;
+        updatePreferredSize();
+        revalidate();
+        repaint();
+    }
+
+    public void setShowPassabilityOverlay(boolean show) {
+        this.showPassabilityOverlay = show;
+        repaint();
+    }
+
+    public void setShowZoneOverlay(boolean show) {
+        this.showZoneOverlay = show;
+        repaint();
+    }
+
+    public void setPaintListener(Consumer<PaintRequest> listener) {
+        this.paintListener = listener;
+    }
+
+    public void setHoverListener(Consumer<Point> listener) {
+        this.hoverListener = listener;
+    }
+
+    private void updatePreferredSize() {
+        if (map == null) {
+            setPreferredSize(new Dimension(400, 400));
+            return;
+        }
+        setPreferredSize(new Dimension(map.getWidth() * tileSize, map.getHeight() * tileSize));
+    }
+
+    @Override
+    protected void paintComponent(Graphics g) {
+        super.paintComponent(g);
+        if (map == null) {
+            return;
+        }
+        Graphics2D g2d = (Graphics2D) g.create();
+        g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        int width = map.getWidth();
+        int height = map.getHeight();
+        int worldStartX = map.getX();
+        int worldStartY = map.getY();
+        for (int x = 0; x < width; x++) {
+            for (int y = 0; y < height; y++) {
+                int worldX = worldStartX + x;
+                int worldY = worldStartY + y;
+                int tile = map.getOriginalTile(worldX, worldY);
+                Color color = colorForTile(tile);
+                g2d.setColor(color);
+                g2d.fillRect(x * tileSize, y * tileSize, tileSize, tileSize);
+
+                if (showZoneOverlay) {
+                    drawZoneOverlay(g2d, worldX, worldY, x, y);
+                }
+                if (showPassabilityOverlay) {
+                    drawPassabilityOverlay(g2d, worldX, worldY, x, y);
+                }
+            }
+        }
+
+        g2d.setColor(new Color(0, 0, 0, 60));
+        for (int x = 0; x <= width; x++) {
+            g2d.drawLine(x * tileSize, 0, x * tileSize, height * tileSize);
+        }
+        for (int y = 0; y <= height; y++) {
+            g2d.drawLine(0, y * tileSize, width * tileSize, y * tileSize);
+        }
+
+        if (previewRectangle != null) {
+            g2d.setColor(new Color(255, 255, 0, 120));
+            g2d.fillRect(previewRectangle.x * tileSize, previewRectangle.y * tileSize,
+                    previewRectangle.width * tileSize, previewRectangle.height * tileSize);
+        }
+
+        if (hoverTile != null) {
+            g2d.setColor(new Color(255, 255, 255, 150));
+            g2d.setStroke(new BasicStroke(2));
+            g2d.drawRect(hoverTile.x * tileSize, hoverTile.y * tileSize, tileSize, tileSize);
+        }
+
+        g2d.dispose();
+    }
+
+    private void drawPassabilityOverlay(Graphics2D g2d, int worldX, int worldY, int tileX, int tileY) {
+        if (map.isImpassable(worldX, worldY)) {
+            g2d.setColor(new Color(200, 0, 0, 120));
+        } else {
+            g2d.setColor(new Color(0, 200, 0, 80));
+        }
+        g2d.fillRect(tileX * tileSize, tileY * tileSize, tileSize, tileSize);
+    }
+
+    private void drawZoneOverlay(Graphics2D g2d, int worldX, int worldY, int tileX, int tileY) {
+        Color overlay;
+        if (map.isSafetyZone(worldX, worldY)) {
+            overlay = new Color(0, 120, 255, 90);
+        } else if (map.isCombatZone(worldX, worldY)) {
+            overlay = new Color(255, 120, 0, 90);
+        } else {
+            overlay = new Color(255, 255, 255, 30);
+        }
+        g2d.setColor(overlay);
+        g2d.fillRect(tileX * tileSize, tileY * tileSize, tileSize, tileSize);
+    }
+
+    private Color colorForTile(int tile) {
+        float hue = (tile % 360) / 360f;
+        float saturation = 0.4f + ((tile % 5) * 0.1f);
+        float brightness = 0.6f + ((tile % 3) * 0.1f);
+        return Color.getHSBColor(hue, Math.min(1f, saturation), Math.min(1f, brightness));
+    }
+}

--- a/tool/map-editor/src/main/java/tool/mapeditor/ui/MinimapPanel.java
+++ b/tool/map-editor/src/main/java/tool/mapeditor/ui/MinimapPanel.java
@@ -1,0 +1,62 @@
+package tool.mapeditor.ui;
+
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Image;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
+
+import javax.swing.JPanel;
+
+import tool.mapeditor.model.EditableL1Map;
+
+public class MinimapPanel extends JPanel {
+    private BufferedImage minimapImage;
+
+    public MinimapPanel() {
+        setPreferredSize(new Dimension(180, 180));
+    }
+
+    public void setMap(EditableL1Map map) {
+        if (map == null) {
+            minimapImage = null;
+            repaint();
+            return;
+        }
+        int width = Math.max(1, map.getWidth());
+        int height = Math.max(1, map.getHeight());
+        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+        for (int x = 0; x < width; x++) {
+            for (int y = 0; y < height; y++) {
+                int worldX = map.getX() + x;
+                int worldY = map.getY() + y;
+                int tile = map.getOriginalTile(worldX, worldY);
+                int color = java.awt.Color.getHSBColor((tile % 360) / 360f, 0.6f, 0.8f).getRGB();
+                if (map.isImpassable(worldX, worldY)) {
+                    color = 0xAAFF0000;
+                } else if (map.isSafetyZone(worldX, worldY)) {
+                    color = 0x8800AAFF;
+                } else if (map.isCombatZone(worldX, worldY)) {
+                    color = 0x88FF8800;
+                }
+                image.setRGB(x, y, color);
+            }
+        }
+        minimapImage = image;
+        repaint();
+    }
+
+    @Override
+    protected void paintComponent(Graphics g) {
+        super.paintComponent(g);
+        if (minimapImage == null) {
+            return;
+        }
+        Graphics2D g2d = (Graphics2D) g.create();
+        g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+        Image scaled = minimapImage.getScaledInstance(getWidth(), getHeight(), Image.SCALE_SMOOTH);
+        g2d.drawImage(scaled, 0, 0, getWidth(), getHeight(), null);
+        g2d.dispose();
+    }
+}

--- a/tool/map-editor/src/main/java/tool/mapeditor/ui/PalettePanel.java
+++ b/tool/map-editor/src/main/java/tool/mapeditor/ui/PalettePanel.java
@@ -1,0 +1,123 @@
+package tool.mapeditor.ui;
+
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+
+import javax.swing.ButtonGroup;
+import javax.swing.JComboBox;
+import javax.swing.JCheckBox;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JSpinner;
+import javax.swing.JToggleButton;
+import javax.swing.SpinnerNumberModel;
+
+import tool.mapeditor.model.ZoneType;
+
+public class PalettePanel extends JPanel {
+    private final JSpinner tileSpinner;
+    private final JCheckBox passableCheck;
+    private final JComboBox<ZoneType> zoneCombo;
+    private final JToggleButton brushToggle;
+    private final JToggleButton rectangleToggle;
+    private final JCheckBox passabilityOverlayCheck;
+    private final JCheckBox zoneOverlayCheck;
+
+    public PalettePanel() {
+        setLayout(new GridBagLayout());
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.insets = new Insets(4, 4, 4, 4);
+        gbc.anchor = GridBagConstraints.WEST;
+        gbc.gridx = 0;
+        gbc.gridy = 0;
+
+        add(new JLabel("Tile ID"), gbc);
+        gbc.gridx = 1;
+        tileSpinner = new JSpinner(new SpinnerNumberModel(0, 0, 255, 1));
+        add(tileSpinner, gbc);
+
+        gbc.gridx = 0;
+        gbc.gridy++;
+        add(new JLabel("Zone"), gbc);
+        gbc.gridx = 1;
+        zoneCombo = new JComboBox<>(ZoneType.values());
+        zoneCombo.setSelectedItem(ZoneType.NORMAL);
+        add(zoneCombo, gbc);
+
+        gbc.gridx = 0;
+        gbc.gridy++;
+        add(new JLabel("Passable"), gbc);
+        gbc.gridx = 1;
+        passableCheck = new JCheckBox();
+        passableCheck.setSelected(true);
+        add(passableCheck, gbc);
+
+        gbc.gridx = 0;
+        gbc.gridy++;
+        add(new JLabel("Tool"), gbc);
+        gbc.gridx = 1;
+        JPanel toolPanel = new JPanel();
+        brushToggle = new JToggleButton("Brush");
+        rectangleToggle = new JToggleButton("Rectangle");
+        ButtonGroup group = new ButtonGroup();
+        group.add(brushToggle);
+        group.add(rectangleToggle);
+        brushToggle.setSelected(true);
+        toolPanel.add(brushToggle);
+        toolPanel.add(rectangleToggle);
+        add(toolPanel, gbc);
+
+        gbc.gridx = 0;
+        gbc.gridy++;
+        add(new JLabel("Overlays"), gbc);
+        gbc.gridx = 1;
+        JPanel overlayPanel = new JPanel();
+        passabilityOverlayCheck = new JCheckBox("Passability");
+        passabilityOverlayCheck.setSelected(true);
+        zoneOverlayCheck = new JCheckBox("Zones");
+        overlayPanel.add(passabilityOverlayCheck);
+        overlayPanel.add(zoneOverlayCheck);
+        add(overlayPanel, gbc);
+    }
+
+    public int getSelectedTileId() {
+        return (Integer) tileSpinner.getValue();
+    }
+
+    public void setSelectedTileId(int tileId) {
+        tileSpinner.setValue(tileId);
+    }
+
+    public boolean isPassableSelected() {
+        return passableCheck.isSelected();
+    }
+
+    public void setPassableSelected(boolean value) {
+        passableCheck.setSelected(value);
+    }
+
+    public ZoneType getSelectedZone() {
+        return (ZoneType) zoneCombo.getSelectedItem();
+    }
+
+    public void setSelectedZone(ZoneType zone) {
+        zoneCombo.setSelectedItem(zone);
+    }
+
+    public JToggleButton getBrushToggle() {
+        return brushToggle;
+    }
+
+    public JToggleButton getRectangleToggle() {
+        return rectangleToggle;
+    }
+
+    public JCheckBox getPassabilityOverlayCheck() {
+        return passabilityOverlayCheck;
+    }
+
+    public JCheckBox getZoneOverlayCheck() {
+        return zoneOverlayCheck;
+    }
+}


### PR DESCRIPTION
## Summary
- add a Swing-based map editor under `tool/map-editor` with brush/rectangle painting, overlays, minimap, and undo/redo
- provide CSV loader/writer utilities and an editable `L1Map` implementation for working directly with existing map data
- document usage and integrate build/run instructions for the new tool into the root README

## Testing
- not run (Apache Ant is not available in the container)

------
https://chatgpt.com/codex/tasks/task_e_68e0bb3a75548332a7270ed21cf77260