### PR TITLE
Align weapon proc damage system message formatting

### DIFF
--- a/src/l1j/server/server/model/L1Attack.java
+++ b/src/l1j/server/server/model/L1Attack.java
@@ -1467,7 +1467,7 @@ public class L1Attack {
 		} else if (_calcType == NPC_PC) {
 			_npc.receiveDamage(_targetPc, damage);
 			if (_targetPc.getDmgMessages()) {
-				_targetPc.sendPackets(new S_SystemMessage("CB Dealt:" + String.valueOf(damage)));
+				_targetPc.sendPackets(new S_SystemMessage("CB Dealt:" + String.valueOf(damage) + " (Counter Barrier)"));
 			}
 		}
 	}

--- a/src/l1j/server/server/model/L1Chaser.java
+++ b/src/l1j/server/server/model/L1Chaser.java
@@ -115,7 +115,7 @@ public class L1Chaser implements Runnable {
 			npc.receiveDamage(_pc, (int) damage);
 		}
 		if (_pc.getDmgMessages() && _cha instanceof L1NpcInstance) {
-			_pc.sendPackets(new S_SystemMessage("Chaser Dealt:" + String.valueOf((int) damage)));
+			_pc.sendPackets(new S_SystemMessage("Chaser Dealt:" + String.valueOf((int) damage) + " (Chaser)"));
 		}
 	}
 

--- a/src/l1j/server/server/model/L1Magic.java
+++ b/src/l1j/server/server/model/L1Magic.java
@@ -376,7 +376,8 @@ public class L1Magic {
 		}
 		damage = skillId == JOY_OF_PAIN ? damage : calcMrDefense(damage);
 		if (_calcType == PC_NPC && _pc.getDmgMessages()) {
-			_pc.sendPackets(new S_SystemMessage(L1NamedSkill.getName(skillId) + " Dealt:" + String.valueOf(damage)));
+			String skillName = L1NamedSkill.getName(skillId);
+			_pc.sendPackets(new S_SystemMessage(skillName + " Dealt:" + String.valueOf(damage) + " (" + skillName + ")"));
 		}
 		return damage;
 	}


### PR DESCRIPTION
## Summary
- append a "(Chaser)" suffix to the chaser damage message for clarity
- include the "(Counter Barrier)" label on counter barrier damage notifications
- align named skill proc damage messages with the new suffix format for consistency

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1192c30d0833291570e94667338b2