### PR TITLE
Update MapEditor to .NET 8 LTS

### DIFF
--- a/tool/map-editor-cs/MapEditor/MapEditor.csproj
+++ b/tool/map-editor-cs/MapEditor/MapEditor.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 </Project>

--- a/tool/map-editor-cs/README.md
+++ b/tool/map-editor-cs/README.md
@@ -17,7 +17,7 @@ without installing Java.
 
 ## Requirements
 
-- .NET 6 SDK or higher on Windows (download from https://dotnet.microsoft.com/).
+- .NET 8 SDK (LTS) on Windows (download from https://dotnet.microsoft.com/).
 - No Java runtime is required for the C# editor.
 
 ## Running the editor
@@ -54,5 +54,5 @@ dotnet publish -c Release -r win-x64 --self-contained true -p:PublishSingleFile=
 ```
 
 The published executable appears under
-`bin/Release/net6.0-windows/win-x64/publish/MapEditor.exe`. Copy the `maps`
+`bin/Release/net8.0-windows10.0.19041.0/win-x64/publish/MapEditor.exe`. Copy the `maps`
 folder alongside the executable so the editor can locate the CSV files.


### PR DESCRIPTION
## Summary
- retarget the Windows map editor WinForms project to net8.0-windows10.0.19041.0 and enable Windows targeting for cross-builds
- document the new .NET 8 SDK requirement and updated publish output path in the editor README

## Testing
- dotnet run *(fails on Linux because the Windows Desktop runtime is unavailable, but the build completed with net8.0 targeting)*
- dotnet publish -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true


------
https://chatgpt.com/codex/tasks/task_e_68e12b42dd9483328aa6a1200a8930f1