### PR TITLE
Update MapEditor to target .NET 8

### DIFF
--- a/tool/map-editor-cs/MapEditor/Forms/MapEditorForm.cs
+++ b/tool/map-editor-cs/MapEditor/Forms/MapEditorForm.cs
@@ -268,8 +268,8 @@ public class MapEditorForm : Form
         _selectedTile = _palette.SelectedTile;
         _snapshotCaptured = false;
         UpdateTileArtVisibility();
-    
 
+    }
 
     private IEnumerable<short> AllTiles(EditableL1Map map)
     {

--- a/tool/map-editor-cs/MapEditor/MapEditor.csproj
+++ b/tool/map-editor-cs/MapEditor/MapEditor.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
## Summary
- retarget the MapEditor project to net8.0-windows with the base .NET SDK
- restore the missing brace so private methods remain inside the form class

## Testing
- not run (dotnet CLI is unavailable in the container environment)


------
https://chatgpt.com/codex/tasks/task_e_68e14e3f07b88332bca222badd9daa42