### PR TITLE
Add map editor sessions and command

### DIFF
--- a/src/l1j/server/server/command/executor/L1MapEditor.java
+++ b/src/l1j/server/server/command/executor/L1MapEditor.java
@@ -1,0 +1,366 @@
+package l1j.server.server.command.executor;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import l1j.server.server.model.Instance.L1PcInstance;
+import l1j.server.server.model.map.edit.MapEditManager;
+import l1j.server.server.model.map.edit.MapEditOperation;
+import l1j.server.server.model.map.edit.MapEditSession;
+import l1j.server.server.model.map.edit.MapEditSession.BrushMode;
+import l1j.server.server.model.map.edit.MapEditSession.TileChangeSummary;
+import l1j.server.server.model.map.edit.MapEditSession.ZoneSetting;
+import l1j.server.server.serverpackets.S_SystemMessage;
+
+public class L1MapEditor implements L1CommandExecutor {
+
+        private static final Logger _log = LoggerFactory.getLogger(L1MapEditor.class);
+
+        private static final int PREVIEW_LIMIT = 5;
+        private static final String BRUSH_USAGE = "Usage: .map brush [tile <id>|tile none|zone <type>|passable <on|off|clear>"
+                        + "|size <value>|info]";
+
+        public static L1CommandExecutor getInstance() {
+                return new L1MapEditor();
+        }
+
+        private L1MapEditor() {
+        }
+
+        @Override
+        public void execute(L1PcInstance pc, String cmdName, String arg) {
+                if (pc == null) {
+                        return;
+                }
+                String[] parts = arg == null ? new String[0] : arg.trim().split("\\s+");
+                if (parts.length == 0 || parts[0].isEmpty()) {
+                        sendHelp(pc);
+                        return;
+                }
+
+                String subCommand = parts[0].toLowerCase();
+                MapEditManager manager = MapEditManager.getInstance();
+
+                try {
+                        switch (subCommand) {
+                        case "start":
+                                handleStart(pc, manager);
+                                break;
+                        case "brush":
+                                handleBrush(pc, manager, parts);
+                                break;
+                        case "mode":
+                                handleMode(pc, manager, parts);
+                                break;
+                        case "apply":
+                                handleApply(pc, manager, parts);
+                                break;
+                        case "undo":
+                                handleUndo(pc, manager);
+                                break;
+                        case "redo":
+                                handleRedo(pc, manager);
+                                break;
+                        case "preview":
+                                handlePreview(pc, manager);
+                                break;
+                        case "commit":
+                                handleCommit(pc, manager);
+                                break;
+                        case "cancel":
+                                handleCancel(pc, manager);
+                                break;
+                        default:
+                                sendHelp(pc);
+                                break;
+                        }
+                } catch (Exception ex) {
+                        _log.warn("Map editor command failed", ex);
+                        pc.sendPackets(new S_SystemMessage("Map editor error: " + ex.getMessage()));
+                }
+        }
+
+        private void handleStart(L1PcInstance pc, MapEditManager manager) {
+                MapEditSession existing = manager.getSession(pc);
+                MapEditSession session = manager.startSession(pc);
+                if (existing == null) {
+                        pc.sendPackets(new S_SystemMessage("Map editing session active on map " + session.getMapId() + "."));
+                } else {
+                        pc.sendPackets(new S_SystemMessage("Resuming map editing session on map " + session.getMapId() + "."));
+                }
+                if (session.hasPendingChanges()) {
+                        pc.sendPackets(new S_SystemMessage("Pending edits: " + session.getPendingChangeCount()));
+                }
+                pc.sendPackets(new S_SystemMessage("Brush: " + session.describeBrush()));
+        }
+
+        private void handleBrush(L1PcInstance pc, MapEditManager manager, String[] parts) {
+                MapEditSession session = requireSession(pc, manager);
+                if (session == null) {
+                        return;
+                }
+                if (parts.length < 2) {
+                        pc.sendPackets(new S_SystemMessage(BRUSH_USAGE));
+                        return;
+                }
+                String brushCommand = parts[1].toLowerCase();
+                switch (brushCommand) {
+                case "tile":
+                        if (parts.length < 3) {
+                                pc.sendPackets(new S_SystemMessage("Usage: .map brush tile <id|none>"));
+                                return;
+                        }
+                        if ("none".equalsIgnoreCase(parts[2])) {
+                                session.clearBrushTile();
+                                pc.sendPackets(new S_SystemMessage("Brush tile cleared."));
+                                break;
+                        }
+                        try {
+                                short tile = Short.parseShort(parts[2]);
+                                session.setBrushTileId(tile);
+                                pc.sendPackets(new S_SystemMessage("Brush tile set to " + tile + "."));
+                        } catch (NumberFormatException ex) {
+                                pc.sendPackets(new S_SystemMessage("Invalid tile id."));
+                        }
+                        break;
+                case "zone":
+                        if (parts.length < 3) {
+                                pc.sendPackets(new S_SystemMessage("Usage: .map brush zone <none|normal|safety|combat>"));
+                                return;
+                        }
+                        ZoneSetting zone = parseZone(parts[2]);
+                        session.setZoneSetting(zone);
+                        pc.sendPackets(new S_SystemMessage("Zone setting set to " + zone.name().toLowerCase() + "."));
+                        break;
+                case "passable":
+                        if (parts.length < 3) {
+                                pc.sendPackets(new S_SystemMessage("Usage: .map brush passable <on|off|clear>"));
+                                return;
+                        }
+                        String passableArg = parts[2].toLowerCase();
+                        if ("on".equals(passableArg) || "true".equals(passableArg)) {
+                                session.setPassableOverride(Boolean.TRUE);
+                                pc.sendPackets(new S_SystemMessage("Brush passable override set to passable."));
+                        } else if ("off".equals(passableArg) || "false".equals(passableArg)) {
+                                session.setPassableOverride(Boolean.FALSE);
+                                pc.sendPackets(new S_SystemMessage("Brush passable override set to blocked."));
+                        } else if ("clear".equals(passableArg)) {
+                                session.clearPassableOverride();
+                                pc.sendPackets(new S_SystemMessage("Brush passable override cleared."));
+                        } else {
+                                pc.sendPackets(new S_SystemMessage("Usage: .map brush passable <on|off|clear>"));
+                        }
+                        break;
+                case "size":
+                        if (parts.length < 3) {
+                                pc.sendPackets(new S_SystemMessage("Usage: .map brush size <value>"));
+                                return;
+                        }
+                        try {
+                                int size = Integer.parseInt(parts[2]);
+                                session.setBrushSize(size);
+                                pc.sendPackets(new S_SystemMessage("Brush size set to " + session.getBrushSize() + "."));
+                        } catch (NumberFormatException ex) {
+                                pc.sendPackets(new S_SystemMessage("Invalid brush size."));
+                        }
+                        break;
+                case "info":
+                        pc.sendPackets(new S_SystemMessage("Brush: " + session.describeBrush()));
+                        break;
+                default:
+                        pc.sendPackets(new S_SystemMessage(BRUSH_USAGE));
+                        break;
+                }
+                pc.sendPackets(new S_SystemMessage("Brush: " + session.describeBrush()));
+        }
+
+        private void handleMode(L1PcInstance pc, MapEditManager manager, String[] parts) {
+                MapEditSession session = requireSession(pc, manager);
+                if (session == null) {
+                        return;
+                }
+                if (parts.length < 2) {
+                        pc.sendPackets(new S_SystemMessage("Usage: .map mode <single|rectangle|radius|fill>"));
+                        return;
+                }
+                BrushMode mode = parseMode(parts[1]);
+                session.setMode(mode);
+                pc.sendPackets(new S_SystemMessage("Brush mode set to " + mode.name().toLowerCase() + "."));
+        }
+
+        private void handleApply(L1PcInstance pc, MapEditManager manager, String[] parts) {
+                MapEditSession session = requireSession(pc, manager);
+                if (session == null) {
+                        return;
+                }
+                int x = pc.getX();
+                int y = pc.getY();
+                if (parts.length >= 3) {
+                        try {
+                                x = Integer.parseInt(parts[1]);
+                                y = Integer.parseInt(parts[2]);
+                        } catch (NumberFormatException ex) {
+                                pc.sendPackets(new S_SystemMessage("Usage: .map apply [x y]"));
+                                return;
+                        }
+                }
+                MapEditOperation operation = session.applyBrush(x, y);
+                if (operation == null) {
+                        pc.sendPackets(new S_SystemMessage("Brush apply made no changes."));
+                        return;
+                }
+                pc.sendPackets(new S_SystemMessage("Applied " + operation.getChangeCount() + " tile(s)."));
+                pc.sendPackets(new S_SystemMessage("Pending edits: " + session.getPendingChangeCount()));
+        }
+
+        private void handleUndo(L1PcInstance pc, MapEditManager manager) {
+                MapEditSession session = requireSession(pc, manager);
+                if (session == null) {
+                        return;
+                }
+                MapEditOperation operation = session.undo();
+                if (operation == null) {
+                        pc.sendPackets(new S_SystemMessage("Nothing to undo."));
+                        return;
+                }
+                pc.sendPackets(new S_SystemMessage("Undid " + operation.getChangeCount() + " tile(s)."));
+                pc.sendPackets(new S_SystemMessage("Pending edits: " + session.getPendingChangeCount()));
+        }
+
+        private void handleRedo(L1PcInstance pc, MapEditManager manager) {
+                MapEditSession session = requireSession(pc, manager);
+                if (session == null) {
+                        return;
+                }
+                MapEditOperation operation = session.redo();
+                if (operation == null) {
+                        pc.sendPackets(new S_SystemMessage("Nothing to redo."));
+                        return;
+                }
+                pc.sendPackets(new S_SystemMessage("Redid " + operation.getChangeCount() + " tile(s)."));
+                pc.sendPackets(new S_SystemMessage("Pending edits: " + session.getPendingChangeCount()));
+        }
+
+        private void handlePreview(L1PcInstance pc, MapEditManager manager) {
+                MapEditSession session = requireSession(pc, manager);
+                if (session == null) {
+                        return;
+                }
+                if (!session.hasPendingChanges()) {
+                        pc.sendPackets(new S_SystemMessage("No pending edits."));
+                        return;
+                }
+                Collection<TileChangeSummary> summaries = session.getPendingChanges();
+                pc.sendPackets(new S_SystemMessage(
+                                "Pending edits: " + summaries.size() + " tile(s). Showing up to " + PREVIEW_LIMIT + "."));
+                List<TileChangeSummary> preview = new ArrayList<>(summaries);
+                preview.sort(Comparator.comparingInt(TileChangeSummary::getX).thenComparingInt(TileChangeSummary::getY));
+                int count = 0;
+                for (TileChangeSummary summary : preview) {
+                        if (count++ >= PREVIEW_LIMIT) {
+                                break;
+                        }
+                        StringBuilder sb = new StringBuilder();
+                        sb.append("Tile (").append(summary.getX()).append(',').append(summary.getY()).append(") ");
+                        if (summary.hasTileChange()) {
+                                sb.append("tile ").append(summary.getOriginalTile()).append(" -> ")
+                                                .append(summary.getCurrentTile());
+                        }
+                        if (summary.hasPassableChange()) {
+                                if (summary.hasTileChange()) {
+                                        sb.append(", ");
+                                }
+                                sb.append("passable ").append(summary.isOriginalPassable() ? "yes" : "no").append(" -> ")
+                                                .append(summary.isCurrentPassable() ? "yes" : "no");
+                        }
+                        pc.sendPackets(new S_SystemMessage(sb.toString()));
+                }
+        }
+
+        private void handleCommit(L1PcInstance pc, MapEditManager manager) {
+                MapEditSession session = requireSession(pc, manager);
+                if (session == null) {
+                        return;
+                }
+                if (!session.hasPendingChanges()) {
+                        pc.sendPackets(new S_SystemMessage("No pending edits to commit."));
+                        return;
+                }
+                try {
+                        int committed = session.commit();
+                        pc.sendPackets(new S_SystemMessage("Committed " + committed + " tile(s) to map " + session.getMapId() + "."));
+                } catch (IOException e) {
+                        _log.error("Failed to commit map edits", e);
+                        pc.sendPackets(new S_SystemMessage("Failed to commit edits: " + e.getMessage()));
+                }
+        }
+
+        private void handleCancel(L1PcInstance pc, MapEditManager manager) {
+                MapEditSession session = manager.getSession(pc);
+                if (session == null) {
+                        pc.sendPackets(new S_SystemMessage("No active map edit session."));
+                        return;
+                }
+                manager.cancelSession(pc);
+                pc.sendPackets(new S_SystemMessage("Map editing session cancelled."));
+        }
+
+        private MapEditSession requireSession(L1PcInstance pc, MapEditManager manager) {
+                MapEditSession session = manager.getSession(pc);
+                if (session == null) {
+                        pc.sendPackets(new S_SystemMessage("No active map edit session. Use .map start first."));
+                        return null;
+                }
+                return session;
+        }
+
+        private void sendHelp(L1PcInstance pc) {
+                pc.sendPackets(new S_SystemMessage(
+                                ".map <start|brush|mode|apply|undo|redo|preview|commit|cancel>"));
+        }
+
+        private ZoneSetting parseZone(String value) {
+                if (value == null) {
+                        return ZoneSetting.NONE;
+                }
+                switch (value.toLowerCase()) {
+                case "normal":
+                        return ZoneSetting.NORMAL;
+                case "safety":
+                case "safe":
+                        return ZoneSetting.SAFETY;
+                case "combat":
+                case "war":
+                        return ZoneSetting.COMBAT;
+                case "none":
+                default:
+                        return ZoneSetting.NONE;
+                }
+        }
+
+        private BrushMode parseMode(String value) {
+                if (value == null) {
+                        return BrushMode.SINGLE;
+                }
+                switch (value.toLowerCase()) {
+                case "rectangle":
+                case "square":
+                        return BrushMode.RECTANGLE;
+                case "radius":
+                case "circle":
+                        return BrushMode.RADIUS;
+                case "fill":
+                case "flood":
+                        return BrushMode.FILL;
+                case "single":
+                default:
+                        return BrushMode.SINGLE;
+                }
+        }
+}

--- a/src/l1j/server/server/command/executor/L1MapInfo.java
+++ b/src/l1j/server/server/command/executor/L1MapInfo.java
@@ -1,73 +1,18 @@
 package l1j.server.server.command.executor;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import l1j.server.server.model.Instance.L1PcInstance;
-import l1j.server.server.serverpackets.S_SystemMessage;
-import l1j.server.server.utils.FileUtil;
 
 public class L1MapInfo implements L1CommandExecutor {
-	/*
-	 * Map IDs 0 = ???? 15 = ???? 16 = fishing zone 21 = safety 47 = combat zone
-	 *
-	 */
-	private static Logger _log = LoggerFactory.getLogger(L1MapInfo.class.getName());
 
-	public static L1CommandExecutor getInstance() {
-		return new L1MapInfo();
-	}
+        private L1MapInfo() {
+        }
 
-	@Override
-	public void execute(L1PcInstance pc, String cmdName, String arg) {
-		ArrayList<String> acceptedCommands = new ArrayList<>(Arrays.asList("info", "update", "revert", "save"));
+        public static L1CommandExecutor getInstance() {
+                return L1MapEditor.getInstance();
+        }
 
-		arg = arg.toLowerCase().trim();
-
-		if (arg.length() == 0) {
-			arg = "info";
-		}
-
-		try {
-			String[] args = arg.split(" ");
-			String command = args[0];
-
-			if (!acceptedCommands.contains(command)) {
-				throw new Exception();
-			}
-
-			switch (command) {
-			case "info":
-				int currentTile = pc.getMap().getOriginalTile(pc.getX(), pc.getY());
-				pc.sendPackets(new S_SystemMessage("Current Tile: " + currentTile));
-				break;
-			case "update":
-				short newValue = Byte.parseByte(args[1]);
-				pc.getMap().setOriginalTile(pc.getX(), pc.getY(), newValue);
-				pc.sendPackets(new S_SystemMessage("Tile updated to: " + newValue));
-				break;
-			case "save":
-				pc.sendPackets(new S_SystemMessage("Starting save.. this may take a second..."));
-				String currentMapFilename = "./maps/" + pc.getMapId() + ".txt";
-				String backupMapFilename = "./maps/" + pc.getMapId() + ".txt.bak";
-
-				FileUtil.copyFileUsingStream(new File(currentMapFilename), new File(backupMapFilename));
-
-				// update the values for the current map
-				FileUtil.writeFile(currentMapFilename, pc.getMap().toCsv());
-
-				pc.sendPackets(new S_SystemMessage("Map " + pc.getMapId() + " new values saved."));
-				pc.sendPackets(new S_SystemMessage("Backup created in the maps directory as " + backupMapFilename));
-				break;
-			}
-
-		} catch (Exception ex) {
-			_log.warn(ex.getLocalizedMessage(), ex);
-			pc.sendPackets(new S_SystemMessage(".map [info|update|save] [newTileValue]"));
-		}
-	}
+        @Override
+        public void execute(L1PcInstance pc, String cmdName, String arg) {
+                L1MapEditor.getInstance().execute(pc, cmdName, arg);
+        }
 }

--- a/src/l1j/server/server/model/map/edit/MapEditManager.java
+++ b/src/l1j/server/server/model/map/edit/MapEditManager.java
@@ -1,0 +1,55 @@
+package l1j.server.server.model.map.edit;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import l1j.server.server.model.Instance.L1PcInstance;
+import l1j.server.server.model.map.L1Map;
+import l1j.server.server.model.map.L1V1Map;
+import l1j.server.server.model.map.L1WorldMap;
+
+/**
+ * Manages active map editing sessions for GMs. Each session is scoped to a
+ * specific player and map.
+ */
+public class MapEditManager {
+
+        private static final MapEditManager INSTANCE = new MapEditManager();
+
+        private final Map<Integer, MapEditSession> sessions = new ConcurrentHashMap<>();
+
+        private MapEditManager() {
+        }
+
+        public static MapEditManager getInstance() {
+                return INSTANCE;
+        }
+
+        public MapEditSession startSession(L1PcInstance pc) {
+                return sessions.compute(pc.getId(), (id, existing) -> {
+                        if (existing != null) {
+                                return existing;
+                        }
+                        L1Map map = L1WorldMap.getInstance().getMap((short) pc.getMapId());
+                        if (!(map instanceof L1V1Map)) {
+                                throw new IllegalStateException("Map " + pc.getMapId() + " is not editable");
+                        }
+                        return new MapEditSession((short) pc.getMapId(), (L1V1Map) map);
+                });
+        }
+
+        public MapEditSession getSession(L1PcInstance pc) {
+                return sessions.get(pc.getId());
+        }
+
+        public void endSession(L1PcInstance pc) {
+                sessions.remove(pc.getId());
+        }
+
+        public void cancelSession(L1PcInstance pc) {
+                MapEditSession session = sessions.remove(pc.getId());
+                if (session != null) {
+                        session.resetWorkingCopy();
+                }
+        }
+}

--- a/src/l1j/server/server/model/map/edit/MapEditOperation.java
+++ b/src/l1j/server/server/model/map/edit/MapEditOperation.java
@@ -1,0 +1,113 @@
+package l1j.server.server.model.map.edit;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import l1j.server.server.model.map.L1V1Map;
+
+/**
+ * Represents a single batch of tile modifications performed by the map editor.
+ * Each operation contains one or more tile changes which can be undone or
+ * redone atomically.
+ */
+public class MapEditOperation {
+
+        private final MapEditSession.BrushMode mode;
+        private final List<MapTileChange> changes = new ArrayList<>();
+
+        public MapEditOperation(MapEditSession.BrushMode mode) {
+                this.mode = mode;
+        }
+
+        public MapEditSession.BrushMode getMode() {
+                return mode;
+        }
+
+        public void addChange(MapTileChange change) {
+                if (change != null) {
+                        changes.add(change);
+                }
+        }
+
+        public boolean isEmpty() {
+                return changes.isEmpty();
+        }
+
+        public int getChangeCount() {
+                return changes.size();
+        }
+
+        public List<MapTileChange> getChanges() {
+                return Collections.unmodifiableList(changes);
+        }
+
+        public void applyTo(L1V1Map map) {
+                for (MapTileChange change : changes) {
+                        map.setOriginalTile(change.getX(), change.getY(), change.getAfterTile());
+                        map.setPassable(change.getX(), change.getY(), change.getAfterPassable());
+                }
+        }
+
+        public void revert(L1V1Map map) {
+                for (MapTileChange change : changes) {
+                        map.setOriginalTile(change.getX(), change.getY(), change.getBeforeTile());
+                        map.setPassable(change.getX(), change.getY(), change.getBeforePassable());
+                }
+        }
+
+        /**
+         * A single tile modification that stores the before and after state so
+         * changes can be reverted or re-applied.
+         */
+        public static class MapTileChange {
+                private final int x;
+                private final int y;
+                private final short beforeTile;
+                private final short afterTile;
+                private final boolean beforePassable;
+                private final boolean afterPassable;
+
+                public MapTileChange(int x, int y, short beforeTile, short afterTile, boolean beforePassable,
+                                boolean afterPassable) {
+                        this.x = x;
+                        this.y = y;
+                        this.beforeTile = beforeTile;
+                        this.afterTile = afterTile;
+                        this.beforePassable = beforePassable;
+                        this.afterPassable = afterPassable;
+                }
+
+                public int getX() {
+                        return x;
+                }
+
+                public int getY() {
+                        return y;
+                }
+
+                public short getBeforeTile() {
+                        return beforeTile;
+                }
+
+                public short getAfterTile() {
+                        return afterTile;
+                }
+
+                public boolean getBeforePassable() {
+                        return beforePassable;
+                }
+
+                public boolean getAfterPassable() {
+                        return afterPassable;
+                }
+
+                public boolean isTileChanged() {
+                        return beforeTile != afterTile;
+                }
+
+                public boolean isPassableChanged() {
+                        return beforePassable != afterPassable;
+                }
+        }
+}

--- a/src/l1j/server/server/model/map/edit/MapEditSession.java
+++ b/src/l1j/server/server/model/map/edit/MapEditSession.java
@@ -1,0 +1,475 @@
+package l1j.server.server.model.map.edit;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.Set;
+
+import l1j.server.server.model.map.L1Map;
+import l1j.server.server.model.map.L1V1Map;
+import l1j.server.server.utils.FileUtil;
+
+/**
+ * Holds the editing state for a GM that is actively modifying a map. Sessions
+ * track brush configuration, pending tile changes, and undo/redo history.
+ */
+public class MapEditSession {
+
+        private static final int ZONE_MASK = 0x30;
+        private static final int IMPASSABLE_BIT = 0x80;
+        private static final int[][] FLOOD_DIRECTIONS = new int[][] { { 1, 0 }, { -1, 0 }, { 0, 1 }, { 0, -1 } };
+
+        public enum BrushMode {
+                SINGLE, RECTANGLE, RADIUS, FILL
+        }
+
+        public enum ZoneSetting {
+                NONE, NORMAL, SAFETY, COMBAT
+        }
+
+        public static class TileChangeSummary {
+                private final int x;
+                private final int y;
+                private final short originalTile;
+                private final boolean originalPassable;
+                private short currentTile;
+                private boolean currentPassable;
+
+                private TileChangeSummary(int x, int y, short originalTile, boolean originalPassable) {
+                        this.x = x;
+                        this.y = y;
+                        this.originalTile = originalTile;
+                        this.originalPassable = originalPassable;
+                        this.currentTile = originalTile;
+                        this.currentPassable = originalPassable;
+                }
+
+                private void setCurrent(short tile, boolean passable) {
+                        this.currentTile = tile;
+                        this.currentPassable = passable;
+                }
+
+                public int getX() {
+                        return x;
+                }
+
+                public int getY() {
+                        return y;
+                }
+
+                public short getOriginalTile() {
+                        return originalTile;
+                }
+
+                public boolean isOriginalPassable() {
+                        return originalPassable;
+                }
+
+                public short getCurrentTile() {
+                        return currentTile;
+                }
+
+                public boolean isCurrentPassable() {
+                        return currentPassable;
+                }
+
+                public boolean hasTileChange() {
+                        return originalTile != currentTile;
+                }
+
+                public boolean hasPassableChange() {
+                        return originalPassable != currentPassable;
+                }
+        }
+
+        private static class TileKey {
+                private final int x;
+                private final int y;
+
+                private TileKey(int x, int y) {
+                        this.x = x;
+                        this.y = y;
+                }
+
+                @Override
+                public int hashCode() {
+                        return Objects.hash(x, y);
+                }
+
+                @Override
+                public boolean equals(Object obj) {
+                        if (this == obj) {
+                                return true;
+                        }
+                        if (!(obj instanceof TileKey)) {
+                                return false;
+                        }
+                        TileKey other = (TileKey) obj;
+                        return x == other.x && y == other.y;
+                }
+        }
+
+        private final short mapId;
+        private final L1V1Map sourceMap;
+        private L1V1Map workingMap;
+        private final Map<TileKey, TileChangeSummary> pendingChanges = new HashMap<>();
+        private final Deque<MapEditOperation> undoStack = new ArrayDeque<>();
+        private final Deque<MapEditOperation> redoStack = new ArrayDeque<>();
+
+        private BrushMode mode = BrushMode.SINGLE;
+        private int brushSize = 1;
+        private Short brushTileId = null;
+        private ZoneSetting zoneSetting = ZoneSetting.NONE;
+        private Boolean passableOverride = null;
+
+        public MapEditSession(short mapId, L1V1Map sourceMap) {
+                this.mapId = mapId;
+                this.sourceMap = sourceMap;
+                this.workingMap = new L1V1Map(sourceMap);
+        }
+
+        public short getMapId() {
+                return mapId;
+        }
+
+        public BrushMode getMode() {
+                return mode;
+        }
+
+        public void setMode(BrushMode mode) {
+                this.mode = mode;
+        }
+
+        public int getBrushSize() {
+                return brushSize;
+        }
+
+        public void setBrushSize(int brushSize) {
+                this.brushSize = Math.max(1, brushSize);
+        }
+
+        public Short getBrushTileId() {
+                return brushTileId;
+        }
+
+        public void setBrushTileId(Short brushTileId) {
+                this.brushTileId = brushTileId;
+        }
+
+        public ZoneSetting getZoneSetting() {
+                return zoneSetting;
+        }
+
+        public void setZoneSetting(ZoneSetting zoneSetting) {
+                this.zoneSetting = zoneSetting;
+        }
+
+        public Boolean getPassableOverride() {
+                return passableOverride;
+        }
+
+        public void setPassableOverride(Boolean passableOverride) {
+                this.passableOverride = passableOverride;
+        }
+
+        public void clearBrushTile() {
+                this.brushTileId = null;
+        }
+
+        public void clearPassableOverride() {
+                this.passableOverride = null;
+        }
+
+        public void clearZoneSetting() {
+                this.zoneSetting = ZoneSetting.NONE;
+        }
+
+        public String describeBrush() {
+                StringBuilder sb = new StringBuilder();
+                sb.append("Mode=").append(mode.name().toLowerCase());
+                sb.append(", Size=").append(brushSize);
+                sb.append(", Tile=").append(brushTileId == null ? "unchanged" : brushTileId);
+                sb.append(", Zone=").append(zoneSetting.name().toLowerCase());
+                sb.append(", Passable=");
+                if (passableOverride == null) {
+                        sb.append("unchanged");
+                } else {
+                        sb.append(passableOverride ? "passable" : "blocked");
+                }
+                return sb.toString();
+        }
+
+        public MapEditOperation applyBrush(int baseX, int baseY) {
+                MapEditOperation operation = new MapEditOperation(mode);
+                switch (mode) {
+                case SINGLE:
+                        applySingle(baseX, baseY, operation);
+                        break;
+                case RECTANGLE:
+                        applyRectangle(baseX, baseY, operation);
+                        break;
+                case RADIUS:
+                        applyRadius(baseX, baseY, operation);
+                        break;
+                case FILL:
+                        applyFloodFill(baseX, baseY, operation);
+                        break;
+                }
+
+                if (operation.isEmpty()) {
+                        return null;
+                }
+
+                undoStack.push(operation);
+                redoStack.clear();
+                return operation;
+        }
+
+        private void applySingle(int x, int y, MapEditOperation operation) {
+                MapEditOperation.MapTileChange change = applyTile(x, y);
+                if (change != null) {
+                        operation.addChange(change);
+                }
+        }
+
+        private void applyRectangle(int centerX, int centerY, MapEditOperation operation) {
+                int radius = Math.max(0, brushSize - 1);
+                for (int dx = -radius; dx <= radius; dx++) {
+                        for (int dy = -radius; dy <= radius; dy++) {
+                                MapEditOperation.MapTileChange change = applyTile(centerX + dx, centerY + dy);
+                                if (change != null) {
+                                        operation.addChange(change);
+                                }
+                        }
+                }
+        }
+
+        private void applyRadius(int centerX, int centerY, MapEditOperation operation) {
+                int radius = Math.max(0, brushSize - 1);
+                int radiusSquared = radius * radius;
+                for (int dx = -radius; dx <= radius; dx++) {
+                        for (int dy = -radius; dy <= radius; dy++) {
+                                if (dx * dx + dy * dy > radiusSquared) {
+                                        continue;
+                                }
+                                MapEditOperation.MapTileChange change = applyTile(centerX + dx, centerY + dy);
+                                if (change != null) {
+                                        operation.addChange(change);
+                                }
+                        }
+                }
+        }
+
+        private void applyFloodFill(int startX, int startY, MapEditOperation operation) {
+                if (!workingMap.isInMap(startX, startY)) {
+                        return;
+                }
+
+                short targetTile = (short) workingMap.getOriginalTile(startX, startY);
+                int radius = Math.max(0, brushSize - 1);
+
+                Queue<TileKey> queue = new ArrayDeque<>();
+                Set<TileKey> visited = new HashSet<>();
+                TileKey start = new TileKey(startX, startY);
+                queue.add(start);
+                visited.add(start);
+
+                while (!queue.isEmpty()) {
+                        TileKey key = queue.poll();
+                        short currentTile = (short) workingMap.getOriginalTile(key.x, key.y);
+                        if (currentTile != targetTile) {
+                                continue;
+                        }
+                        MapEditOperation.MapTileChange change = applyTile(key.x, key.y);
+                        if (change != null) {
+                                operation.addChange(change);
+                        }
+
+                        for (int[] direction : FLOOD_DIRECTIONS) {
+                                int nextX = key.x + direction[0];
+                                int nextY = key.y + direction[1];
+                                TileKey nextKey = new TileKey(nextX, nextY);
+                                if (visited.contains(nextKey)) {
+                                        continue;
+                                }
+                                if (!workingMap.isInMap(nextX, nextY)) {
+                                        continue;
+                                }
+                                if (radius > 0 && (Math.abs(nextX - startX) > radius || Math.abs(nextY - startY) > radius)) {
+                                        continue;
+                                }
+                                if ((short) workingMap.getOriginalTile(nextX, nextY) != targetTile) {
+                                        continue;
+                                }
+                                visited.add(nextKey);
+                                queue.add(nextKey);
+                        }
+                }
+        }
+
+        private MapEditOperation.MapTileChange applyTile(int x, int y) {
+                if (!workingMap.isInMap(x, y)) {
+                        return null;
+                }
+                int localX = x - workingMap.getX();
+                int localY = y - workingMap.getY();
+                byte[][] tiles = workingMap.getRawTiles();
+                if (localX < 0 || localX >= tiles.length) {
+                        return null;
+                }
+                if (localY < 0 || localY >= tiles[localX].length) {
+                        return null;
+                }
+
+                short beforeTile = (short) workingMap.getOriginalTile(x, y);
+                boolean beforePassable = (tiles[localX][localY] & IMPASSABLE_BIT) == 0;
+
+                short newTile = beforeTile;
+                if (brushTileId != null) {
+                        newTile = brushTileId;
+                }
+                newTile = applyZoneSetting(newTile);
+                boolean newPassable = passableOverride != null ? passableOverride.booleanValue() : beforePassable;
+
+                boolean tileChanged = newTile != beforeTile;
+                boolean passableChanged = newPassable != beforePassable;
+
+                if (!tileChanged && !passableChanged) {
+                        return null;
+                }
+
+                workingMap.setOriginalTile(x, y, newTile);
+                workingMap.setPassable(x, y, newPassable);
+
+                MapEditOperation.MapTileChange change = new MapEditOperation.MapTileChange(x, y, beforeTile, newTile,
+                                beforePassable, newPassable);
+                updatePendingChange(x, y, change.getAfterTile(), change.getAfterPassable());
+                return change;
+        }
+
+        private short applyZoneSetting(short tile) {
+                switch (zoneSetting) {
+                case NORMAL:
+                        return (short) (tile & ~ZONE_MASK);
+                case SAFETY:
+                        return (short) ((tile & ~ZONE_MASK) | 0x10);
+                case COMBAT:
+                        return (short) ((tile & ~ZONE_MASK) | 0x20);
+                case NONE:
+                default:
+                        return tile;
+                }
+        }
+
+        public MapEditOperation undo() {
+                if (undoStack.isEmpty()) {
+                        return null;
+                }
+                MapEditOperation operation = undoStack.pop();
+                operation.revert(workingMap);
+                for (MapEditOperation.MapTileChange change : operation.getChanges()) {
+                        updatePendingChange(change.getX(), change.getY(), change.getBeforeTile(), change.getBeforePassable());
+                }
+                redoStack.push(operation);
+                return operation;
+        }
+
+        public MapEditOperation redo() {
+                if (redoStack.isEmpty()) {
+                        return null;
+                }
+                MapEditOperation operation = redoStack.pop();
+                operation.applyTo(workingMap);
+                for (MapEditOperation.MapTileChange change : operation.getChanges()) {
+                        updatePendingChange(change.getX(), change.getY(), change.getAfterTile(), change.getAfterPassable());
+                }
+                undoStack.push(operation);
+                return operation;
+        }
+
+        public void resetWorkingCopy() {
+                this.workingMap = new L1V1Map(sourceMap);
+                pendingChanges.clear();
+                undoStack.clear();
+                redoStack.clear();
+        }
+
+        public boolean hasPendingChanges() {
+                return !pendingChanges.isEmpty();
+        }
+
+        public int getPendingChangeCount() {
+                return pendingChanges.size();
+        }
+
+        public Collection<TileChangeSummary> getPendingChanges() {
+                return Collections.unmodifiableCollection(pendingChanges.values());
+        }
+
+        public int commit() throws IOException {
+                if (pendingChanges.isEmpty()) {
+                        return 0;
+                }
+                int changedTiles = pendingChanges.size();
+                for (TileChangeSummary summary : new ArrayList<>(pendingChanges.values())) {
+                        sourceMap.setOriginalTile(summary.getX(), summary.getY(), summary.getCurrentTile());
+                        sourceMap.setPassable(summary.getX(), summary.getY(), summary.isCurrentPassable());
+                }
+
+                String mapFilename = "./maps/" + mapId + ".txt";
+                File mapFile = new File(mapFilename);
+                if (mapFile.exists()) {
+                        File backupFile = new File(mapFilename + ".bak");
+                        FileUtil.copyFileUsingStream(mapFile, backupFile);
+                }
+                FileUtil.writeFile(mapFilename, sourceMap.toCsv());
+
+                resetWorkingCopy();
+                return changedTiles;
+        }
+
+        private void updatePendingChange(int x, int y, short currentTile, boolean currentPassable) {
+                TileKey key = new TileKey(x, y);
+                short originalTile = (short) sourceMap.getOriginalTile(x, y);
+                boolean originalPassable = isPassable(sourceMap, x, y);
+                if (currentTile == originalTile && currentPassable == originalPassable) {
+                        pendingChanges.remove(key);
+                        return;
+                }
+                TileChangeSummary summary = pendingChanges.get(key);
+                if (summary == null) {
+                        summary = new TileChangeSummary(x, y, originalTile, originalPassable);
+                        pendingChanges.put(key, summary);
+                }
+                summary.setCurrent(currentTile, currentPassable);
+        }
+
+        private boolean isPassable(L1Map map, int x, int y) {
+                if (!(map instanceof L1V1Map)) {
+                        return map.isPassable(x, y);
+                }
+                L1V1Map v1Map = (L1V1Map) map;
+                if (!v1Map.isInMap(x, y)) {
+                        return false;
+                }
+                int localX = x - v1Map.getX();
+                int localY = y - v1Map.getY();
+                byte[][] tiles = v1Map.getRawTiles();
+                if (localX < 0 || localX >= tiles.length) {
+                        return false;
+                }
+                if (localY < 0 || localY >= tiles[localX].length) {
+                        return false;
+                }
+                return (tiles[localX][localY] & IMPASSABLE_BIT) == 0;
+        }
+}


### PR DESCRIPTION
## Summary
- introduce map edit session utilities to track brush settings, pending tile changes, and undo/redo history
- add an `.map` editor command with brush configuration, apply/undo/redo, preview, commit, and cancel support
- replace the legacy `L1MapInfo` executor with a wrapper that delegates to the new editor implementation

## Testing
- ant compile *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e15b097328833283e194724cb10bd5