### PR TITLE
Add map cache regeneration and reload support

### DIFF
--- a/src/l1j/server/server/command/executor/L1MapInfo.java
+++ b/src/l1j/server/server/command/executor/L1MapInfo.java
@@ -7,7 +7,10 @@ import java.util.Arrays;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import l1j.server.Config;
 import l1j.server.server.model.Instance.L1PcInstance;
+import l1j.server.server.model.map.CachedMapReader;
+import l1j.server.server.model.map.L1WorldMap;
 import l1j.server.server.serverpackets.S_SystemMessage;
 import l1j.server.server.utils.FileUtil;
 
@@ -50,22 +53,43 @@ public class L1MapInfo implements L1CommandExecutor {
 				pc.getMap().setOriginalTile(pc.getX(), pc.getY(), newValue);
 				pc.sendPackets(new S_SystemMessage("Tile updated to: " + newValue));
 				break;
-			case "save":
-				pc.sendPackets(new S_SystemMessage("Starting save.. this may take a second..."));
-				String currentMapFilename = "./maps/" + pc.getMapId() + ".txt";
-				String backupMapFilename = "./maps/" + pc.getMapId() + ".txt.bak";
+                        case "save":
+                                int mapId = pc.getMapId();
+                                pc.sendPackets(new S_SystemMessage("Starting save.. this may take a second..."));
+                                String currentMapFilename = "./maps/" + mapId + ".txt";
+                                String backupMapFilename = "./maps/" + mapId + ".txt.bak";
 
-				FileUtil.copyFileUsingStream(new File(currentMapFilename), new File(backupMapFilename));
+                                FileUtil.copyFileUsingStream(new File(currentMapFilename), new File(backupMapFilename));
 
-				// update the values for the current map
-				FileUtil.writeFile(currentMapFilename, pc.getMap().toCsv());
+                                // update the values for the current map
+                                FileUtil.writeFile(currentMapFilename, pc.getMap().toCsv());
 
-				pc.sendPackets(new S_SystemMessage("Map " + pc.getMapId() + " new values saved."));
-				pc.sendPackets(new S_SystemMessage("Backup created in the maps directory as " + backupMapFilename));
-				break;
-			}
+                                pc.sendPackets(new S_SystemMessage("Map " + mapId + " new values saved."));
+                                pc.sendPackets(new S_SystemMessage("Backup created in the maps directory as " + backupMapFilename));
 
-		} catch (Exception ex) {
+                                if (Config.CACHE_MAP_FILES) {
+                                        pc.sendPackets(new S_SystemMessage("Regenerating map cache for map " + mapId + "..."));
+                                        try {
+                                                CachedMapReader.rebuildCache(mapId);
+                                                pc.sendPackets(new S_SystemMessage("Map cache regeneration complete."));
+                                        } catch (Exception e) {
+                                                _log.error(e.getLocalizedMessage(), e);
+                                                pc.sendPackets(new S_SystemMessage("Failed to regenerate map cache: " + e.getMessage()));
+                                        }
+                                }
+
+                                pc.sendPackets(new S_SystemMessage("Reloading world map " + mapId + "..."));
+                                try {
+                                        L1WorldMap.getInstance().reloadMap(mapId);
+                                        pc.sendPackets(new S_SystemMessage("World map reload complete."));
+                                } catch (Exception e) {
+                                        _log.error(e.getLocalizedMessage(), e);
+                                        pc.sendPackets(new S_SystemMessage("Failed to reload world map: " + e.getMessage()));
+                                }
+                                break;
+                        }
+
+                } catch (Exception ex) {
 			_log.warn(ex.getLocalizedMessage(), ex);
 			pc.sendPackets(new S_SystemMessage(".map [info|update|save] [newTileValue]"));
 		}

--- a/src/l1j/server/server/model/map/CachedMapReader.java
+++ b/src/l1j/server/server/model/map/CachedMapReader.java
@@ -59,12 +59,12 @@ public class CachedMapReader extends MapReader {
 		return ids;
 	}
 
-	private L1V1Map cacheMap(final int mapId) throws IOException {
-		File file = new File(CACHE_DIR);
-		if (!file.exists()) {
-			file.mkdir();
-		}
-		L1V1Map map = (L1V1Map) new TextMapReader().read(mapId);
+        private L1V1Map cacheMap(final int mapId) throws IOException {
+                File file = new File(CACHE_DIR);
+                if (!file.exists()) {
+                        file.mkdir();
+                }
+                L1V1Map map = (L1V1Map) new TextMapReader().read(mapId);
 		DataOutputStream out = new DataOutputStream(
 				new BufferedOutputStream(new FileOutputStream(CACHE_DIR + mapId + ".map")));
 		out.writeInt(map.getId());
@@ -113,12 +113,25 @@ public class CachedMapReader extends MapReader {
 		return map;
 	}
 
-	@Override
-	public Map<Integer, L1Map> read() throws IOException {
-		Map<Integer, L1Map> maps = new HashMap<>();
-		for (int id : listMapIds()) {
-			maps.put(id, read(id));
-		}
-		return maps;
-	}
+        @Override
+        public Map<Integer, L1Map> read() throws IOException {
+                Map<Integer, L1Map> maps = new HashMap<>();
+                for (int id : listMapIds()) {
+                        maps.put(id, read(id));
+                }
+                return maps;
+        }
+
+        public static L1Map rebuildCache(int mapId) throws IOException {
+                CachedMapReader reader = new CachedMapReader();
+                return reader.rebuild(mapId);
+        }
+
+        private L1Map rebuild(int mapId) throws IOException {
+                File cacheFile = new File(CACHE_DIR + mapId + ".map");
+                if (cacheFile.exists() && !cacheFile.delete()) {
+                        throw new IOException("Could not delete old map cache file for mapId " + mapId);
+                }
+                return cacheMap(mapId);
+        }
 }

--- a/src/l1j/server/server/model/map/L1V1Map.java
+++ b/src/l1j/server/server/model/map/L1V1Map.java
@@ -113,6 +113,39 @@ public class L1V1Map extends L1Map {
 
 	}
 
+	public void applyFrom(L1V1Map source) {
+		if (source == null) {
+			throw new NullPointerException("source");
+		}
+		if (_mapId != 0 && _mapId != source._mapId) {
+			throw new IllegalArgumentException("Cannot apply mapId " + source._mapId + " to map " + _mapId);
+		}
+
+		_mapId = source._mapId;
+
+		_map = new byte[source._map.length][];
+		for (int i = 0; i < source._map.length; i++) {
+			_map[i] = source._map[i].clone();
+		}
+
+		_worldTopLeftX = source._worldTopLeftX;
+		_worldTopLeftY = source._worldTopLeftY;
+		_worldBottomRightX = source._worldBottomRightX;
+		_worldBottomRightY = source._worldBottomRightY;
+
+		_isUnderwater = source._isUnderwater;
+		_isMarkable = source._isMarkable;
+		_isTeleportable = source._isTeleportable;
+		_isEscapable = source._isEscapable;
+		_isUseResurrection = source._isUseResurrection;
+		_isUsePainwand = source._isUsePainwand;
+		_isEnabledDeathPenalty = source._isEnabledDeathPenalty;
+		_isTakePets = source._isTakePets;
+		_isRecallPets = source._isRecallPets;
+		_isUsableItem = source._isUsableItem;
+		_isUsableSkill = source._isUsableSkill;
+	}
+
 	private int accessTile(int x, int y) {
 		if (!isInMap(x, y)) {
 			return 0;

--- a/src/l1j/server/server/model/map/L1WorldMap.java
+++ b/src/l1j/server/server/model/map/L1WorldMap.java
@@ -67,12 +67,19 @@ public class L1WorldMap {
                 return map;
         }
 
-        public void reloadMap(int mapId) throws IOException {
+        public L1Map reloadMap(int mapId) throws IOException {
                 MapReader reader = MapReader.getDefaultReader();
                 L1Map map = reader.read(mapId);
                 if (map == null) {
                         throw new IOException("Failure to read the map: " + mapId);
                 }
+
+                L1Map existing = _maps.get(mapId);
+                if (existing instanceof L1V1Map && map instanceof L1V1Map) {
+                        ((L1V1Map) existing).applyFrom((L1V1Map) map);
+                        map = existing;
+                }
                 _maps.put(mapId, map);
+                return map;
         }
 }

--- a/src/l1j/server/server/model/map/L1WorldMap.java
+++ b/src/l1j/server/server/model/map/L1WorldMap.java
@@ -18,6 +18,7 @@
  */
 package l1j.server.server.model.map;
 
+import java.io.IOException;
 import java.util.Map;
 
 import org.slf4j.Logger;
@@ -58,11 +59,20 @@ public class L1WorldMap {
 	/**
 	 * The map information to hold L1Map returns.
 	 */
-	public L1Map getMap(short mapId) {
-		L1Map map = _maps.get((int) mapId);
-		if (map == null) {
-			map = L1Map.newNull();
-		}
-		return map;
-	}
+        public L1Map getMap(short mapId) {
+                L1Map map = _maps.get((int) mapId);
+                if (map == null) {
+                        map = L1Map.newNull();
+                }
+                return map;
+        }
+
+        public void reloadMap(int mapId) throws IOException {
+                MapReader reader = MapReader.getDefaultReader();
+                L1Map map = reader.read(mapId);
+                if (map == null) {
+                        throw new IOException("Failure to read the map: " + mapId);
+                }
+                _maps.put(mapId, map);
+        }
 }


### PR DESCRIPTION
## Summary
- add an L1WorldMap.reloadMap helper to refresh a single map entry
- provide a CachedMapReader.rebuildCache utility that deletes stale cache files before regenerating them
- update the .map save command to rebuild cache files, reload the map, and notify the GM of each step

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e15b0d78f483328acf06387b2804f8