### PR TITLE
Add GM map creation and metadata editing commands

### DIFF
--- a/src/l1j/server/server/command/executor/L1MapInfo.java
+++ b/src/l1j/server/server/command/executor/L1MapInfo.java
@@ -1,73 +1,291 @@
 package l1j.server.server.command.executor;
 
 import java.io.File;
-import java.util.ArrayList;
+import java.io.IOException;
+import java.sql.SQLException;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import l1j.server.server.datatables.MapIdsTableEditor;
+import l1j.server.server.datatables.MapsTable;
 import l1j.server.server.model.Instance.L1PcInstance;
+import l1j.server.server.model.map.L1V1Map;
+import l1j.server.server.model.map.L1WorldMap;
 import l1j.server.server.serverpackets.S_SystemMessage;
 import l1j.server.server.utils.FileUtil;
 
 public class L1MapInfo implements L1CommandExecutor {
-	/*
-	 * Map IDs 0 = ???? 15 = ???? 16 = fishing zone 21 = safety 47 = combat zone
-	 *
-	 */
-	private static Logger _log = LoggerFactory.getLogger(L1MapInfo.class.getName());
+        private static final Logger _log = LoggerFactory.getLogger(L1MapInfo.class.getName());
+        private static final String MAP_DIRECTORY = "./maps/";
+        private static final byte DEFAULT_TILE = 0;
 
-	public static L1CommandExecutor getInstance() {
-		return new L1MapInfo();
-	}
+        public static L1CommandExecutor getInstance() {
+                return new L1MapInfo();
+        }
 
-	@Override
-	public void execute(L1PcInstance pc, String cmdName, String arg) {
-		ArrayList<String> acceptedCommands = new ArrayList<>(Arrays.asList("info", "update", "revert", "save"));
+        @Override
+        public void execute(L1PcInstance pc, String cmdName, String arg) {
+                if (pc == null) {
+                        return;
+                }
 
-		arg = arg.toLowerCase().trim();
+                String trimmed = arg == null ? "" : arg.trim();
+                if (trimmed.isEmpty()) {
+                        handleInfo(pc);
+                        return;
+                }
 
-		if (arg.length() == 0) {
-			arg = "info";
-		}
+                String[] args = trimmed.split("\\s+");
+                String command = args[0].toLowerCase(Locale.ENGLISH);
+                try {
+                        switch (command) {
+                        case "info":
+                                handleInfo(pc);
+                                break;
+                        case "update":
+                                handleUpdate(pc, args);
+                                break;
+                        case "save":
+                                handleSave(pc);
+                                break;
+                        case "new":
+                                handleNew(pc, args);
+                                break;
+                        case "meta":
+                                handleMeta(pc, Arrays.copyOfRange(args, 1, args.length));
+                                break;
+                        default:
+                                sendUsage(pc);
+                                break;
+                        }
+                } catch (Exception ex) {
+                        _log.warn(ex.getLocalizedMessage(), ex);
+                        sendUsage(pc);
+                }
+        }
 
-		try {
-			String[] args = arg.split(" ");
-			String command = args[0];
+        private void handleInfo(L1PcInstance pc) {
+                int currentTile = pc.getMap().getOriginalTile(pc.getX(), pc.getY());
+                pc.sendPackets(new S_SystemMessage("Current Tile: " + currentTile));
+        }
 
-			if (!acceptedCommands.contains(command)) {
-				throw new Exception();
-			}
+        private void handleUpdate(L1PcInstance pc, String[] args) {
+                if (args.length < 2) {
+                                throw new IllegalArgumentException("Missing tile value");
+                }
+                short newValue = Byte.parseByte(args[1]);
+                pc.getMap().setOriginalTile(pc.getX(), pc.getY(), newValue);
+                pc.sendPackets(new S_SystemMessage("Tile updated to: " + newValue));
+        }
 
-			switch (command) {
-			case "info":
-				int currentTile = pc.getMap().getOriginalTile(pc.getX(), pc.getY());
-				pc.sendPackets(new S_SystemMessage("Current Tile: " + currentTile));
-				break;
-			case "update":
-				short newValue = Byte.parseByte(args[1]);
-				pc.getMap().setOriginalTile(pc.getX(), pc.getY(), newValue);
-				pc.sendPackets(new S_SystemMessage("Tile updated to: " + newValue));
-				break;
-			case "save":
-				pc.sendPackets(new S_SystemMessage("Starting save.. this may take a second..."));
-				String currentMapFilename = "./maps/" + pc.getMapId() + ".txt";
-				String backupMapFilename = "./maps/" + pc.getMapId() + ".txt.bak";
+        private void handleSave(L1PcInstance pc) throws IOException {
+                pc.sendPackets(new S_SystemMessage("Starting save.. this may take a second..."));
+                String currentMapFilename = MAP_DIRECTORY + pc.getMapId() + ".txt";
+                String backupMapFilename = currentMapFilename + ".bak";
 
-				FileUtil.copyFileUsingStream(new File(currentMapFilename), new File(backupMapFilename));
+                File currentMap = new File(currentMapFilename);
+                if (currentMap.exists()) {
+                        FileUtil.copyFileUsingStream(currentMap, new File(backupMapFilename));
+                }
 
-				// update the values for the current map
-				FileUtil.writeFile(currentMapFilename, pc.getMap().toCsv());
+                FileUtil.writeFile(currentMapFilename, pc.getMap().toCsv());
 
-				pc.sendPackets(new S_SystemMessage("Map " + pc.getMapId() + " new values saved."));
-				pc.sendPackets(new S_SystemMessage("Backup created in the maps directory as " + backupMapFilename));
-				break;
-			}
+                pc.sendPackets(new S_SystemMessage("Map " + pc.getMapId() + " new values saved."));
+                pc.sendPackets(new S_SystemMessage("Backup created in the maps directory as " + backupMapFilename));
+        }
 
-		} catch (Exception ex) {
-			_log.warn(ex.getLocalizedMessage(), ex);
-			pc.sendPackets(new S_SystemMessage(".map [info|update|save] [newTileValue]"));
-		}
-	}
+        private void handleNew(L1PcInstance pc, String[] args) throws SQLException, IOException {
+                if (args.length < 6) {
+                        throw new IllegalArgumentException("Usage: .map new <mapId> <width> <height> <startX> <startY> [flag value]...");
+                }
+
+                int mapId = Integer.parseInt(args[1]);
+                int width = Integer.parseInt(args[2]);
+                int height = Integer.parseInt(args[3]);
+                int startX = Integer.parseInt(args[4]);
+                int startY = Integer.parseInt(args[5]);
+
+                if (width <= 0 || height <= 0) {
+                        throw new IllegalArgumentException("Width and height must be positive integers");
+                }
+
+                Map<String, Boolean> overrides = parseBooleanFlags(args, 6);
+                Map<String, Boolean> flags = MapIdsTableEditor.createDefaultBooleanFlags();
+                for (Map.Entry<String, Boolean> entry : overrides.entrySet()) {
+                        flags.put(entry.getKey(), entry.getValue());
+                }
+
+                int endX = startX + width - 1;
+                int endY = startY + height - 1;
+
+                byte[][] tiles = new byte[width][height];
+                for (int x = 0; x < width; x++) {
+                        Arrays.fill(tiles[x], DEFAULT_TILE);
+                }
+
+                L1V1Map newMap = new L1V1Map(mapId, tiles, startX, startY, getFlag(flags, "underwater"),
+                                getFlag(flags, "markable"), getFlag(flags, "teleportable"), getFlag(flags, "escapable"),
+                                getFlag(flags, "resurrection"), getFlag(flags, "painwand"), getFlag(flags, "penalty"),
+                                getFlag(flags, "take_pets"), getFlag(flags, "recall_pets"), getFlag(flags, "usable_item"),
+                                getFlag(flags, "usable_skill"));
+
+                String locationName = MapsTable.getInstance().locationname(mapId);
+                if (locationName == null || locationName.isEmpty()) {
+                        locationName = "Custom Map " + mapId;
+                }
+
+                MapIdsTableEditor.upsertMapRecord(mapId, startX, endX, startY, endY, flags, locationName);
+                MapsTable.getInstance().reload(mapId);
+
+                File mapFile = new File(MAP_DIRECTORY + mapId + ".txt");
+                if (mapFile.exists()) {
+                        FileUtil.copyFileUsingStream(mapFile, new File(mapFile.getAbsolutePath() + ".bak"));
+                }
+                writeMapFile(newMap);
+
+                L1WorldMap.getInstance().reloadMap(mapId);
+
+                pc.sendPackets(new S_SystemMessage("Map " + mapId + " created with size " + width + "x" + height + "."));
+        }
+
+        private void handleMeta(L1PcInstance pc, String[] args) {
+                if (args.length == 0) {
+                        throw new IllegalArgumentException("Usage: .map meta set [mapId] <flag> <true|false>");
+                }
+
+                String subCommand = args[0].toLowerCase(Locale.ENGLISH);
+                switch (subCommand) {
+                case "set":
+                        handleMetaSet(pc, Arrays.copyOfRange(args, 1, args.length));
+                        break;
+                default:
+                        throw new IllegalArgumentException("Unknown meta command: " + subCommand);
+                }
+        }
+
+        private void handleMetaSet(L1PcInstance pc, String[] args) {
+                if (args.length < 2) {
+                        throw new IllegalArgumentException("Usage: .map meta set [mapId] <flag> <true|false>");
+                }
+
+                int argIndex = 0;
+                int mapId;
+                if (isInteger(args[argIndex])) {
+                        mapId = Integer.parseInt(args[argIndex]);
+                        argIndex++;
+                } else {
+                        mapId = pc.getMapId();
+                }
+
+                if (argIndex >= args.length - 1) {
+                        throw new IllegalArgumentException("Usage: .map meta set [mapId] <flag> <true|false>");
+                }
+
+                String columnToken = args[argIndex++];
+                String valueToken = args[argIndex];
+
+                String normalizedColumn = MapIdsTableEditor.normalizeColumnName(columnToken);
+                if (normalizedColumn == null) {
+                        throw new IllegalArgumentException("Unknown map flag: " + columnToken);
+                }
+
+                boolean newValue = parseBoolean(valueToken);
+                if (!MapIdsTableEditor.updateBooleanFlag(mapId, normalizedColumn, newValue)) {
+                        throw new IllegalStateException("Unable to update flag " + normalizedColumn + " for map " + mapId);
+                }
+
+                MapsTable.getInstance().reload(mapId);
+                L1WorldMap.getInstance().reloadMap(mapId);
+
+                pc.sendPackets(new S_SystemMessage(
+                                "Updated map " + mapId + " flag " + normalizedColumn + " to " + Boolean.toString(newValue)));
+        }
+
+        private Map<String, Boolean> parseBooleanFlags(String[] args, int startIndex) {
+                Map<String, Boolean> values = new LinkedHashMap<>();
+                int index = startIndex;
+                while (index < args.length) {
+                        String token = args[index];
+                        String key;
+                        String value;
+                        if (token.contains("=")) {
+                                String[] parts = token.split("=", 2);
+                                key = parts[0];
+                                value = parts.length > 1 ? parts[1] : "true";
+                                index++;
+                        } else {
+                                key = token;
+                                if (index + 1 >= args.length) {
+                                        throw new IllegalArgumentException("Missing value for flag " + key);
+                                }
+                                value = args[index + 1];
+                                index += 2;
+                        }
+                        String normalized = MapIdsTableEditor.normalizeColumnName(key);
+                        if (normalized == null) {
+                                throw new IllegalArgumentException("Unknown map flag: " + key);
+                        }
+                        values.put(normalized, parseBoolean(value));
+                }
+                return values;
+        }
+
+        private boolean getFlag(Map<String, Boolean> flags, String key) {
+                Boolean value = flags.get(key);
+                return value != null && value;
+        }
+
+        private boolean parseBoolean(String value) {
+                String normalized = value.toLowerCase(Locale.ENGLISH);
+                switch (normalized) {
+                case "true":
+                case "1":
+                case "yes":
+                case "on":
+                        return true;
+                case "false":
+                case "0":
+                case "no":
+                case "off":
+                        return false;
+                default:
+                        throw new IllegalArgumentException("Unknown boolean value: " + value);
+                }
+        }
+
+        private boolean isInteger(String value) {
+                try {
+                        Integer.parseInt(value);
+                        return true;
+                } catch (NumberFormatException ex) {
+                        return false;
+                }
+        }
+
+        private void writeMapFile(L1V1Map map) throws IOException {
+                byte[][] tiles = map.getRawTiles();
+                int width = map.getWidth();
+                int height = map.getHeight();
+                StringBuilder data = new StringBuilder();
+                for (int y = 0; y < height; y++) {
+                        for (int x = 0; x < width; x++) {
+                                data.append(Byte.toUnsignedInt(tiles[x][y]));
+                                if (x < width - 1) {
+                                        data.append(',');
+                                }
+                        }
+                        data.append('\n');
+                }
+                FileUtil.writeFile(MAP_DIRECTORY + map.getId() + ".txt", data.toString());
+        }
+
+        private void sendUsage(L1PcInstance pc) {
+                pc.sendPackets(new S_SystemMessage(
+                                ".map [info|update|save|new|meta set] (see .map meta set [mapId] <flag> <true|false>)"));
+        }
 }

--- a/src/l1j/server/server/datatables/MapIdsTableEditor.java
+++ b/src/l1j/server/server/datatables/MapIdsTableEditor.java
@@ -1,0 +1,149 @@
+package l1j.server.server.datatables;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import l1j.server.L1DatabaseFactory;
+import l1j.server.server.utils.SQLUtil;
+
+public final class MapIdsTableEditor {
+        private static final Logger _log = LoggerFactory.getLogger(MapIdsTableEditor.class);
+
+        private static final Map<String, String> COLUMN_ALIASES;
+
+        static {
+                Map<String, String> aliases = new LinkedHashMap<>();
+                aliases.put("underwater", "underwater");
+                aliases.put("markable", "markable");
+                aliases.put("teleportable", "teleportable");
+                aliases.put("escapable", "escapable");
+                aliases.put("resurrection", "resurrection");
+                aliases.put("painwand", "painwand");
+                aliases.put("penalty", "penalty");
+                aliases.put("take_pets", "take_pets");
+                aliases.put("recall_pets", "recall_pets");
+                aliases.put("usable_item", "usable_item");
+                aliases.put("usable_skill", "usable_skill");
+                COLUMN_ALIASES = Collections.unmodifiableMap(aliases);
+        }
+
+        private MapIdsTableEditor() {
+        }
+
+        public static Map<String, Boolean> createDefaultBooleanFlags() {
+                Map<String, Boolean> defaults = new LinkedHashMap<>();
+                for (String column : COLUMN_ALIASES.values()) {
+                        defaults.put(column, Boolean.FALSE);
+                }
+                return defaults;
+        }
+
+        public static boolean isBooleanColumn(String column) {
+                return COLUMN_ALIASES.containsKey(column.toLowerCase(Locale.ENGLISH));
+        }
+
+        public static Set<String> getSupportedBooleanColumns() {
+                return COLUMN_ALIASES.keySet();
+        }
+
+        public static String normalizeColumnName(String column) {
+                if (column == null) {
+                        return null;
+                }
+                return COLUMN_ALIASES.get(column.toLowerCase(Locale.ENGLISH));
+        }
+
+        public static void upsertMapRecord(int mapId, int startX, int endX, int startY, int endY,
+                        Map<String, Boolean> booleanFlags, String locationName) throws SQLException {
+                Map<String, Boolean> flags = createDefaultBooleanFlags();
+                if (booleanFlags != null) {
+                        for (Map.Entry<String, Boolean> entry : booleanFlags.entrySet()) {
+                                String normalized = normalizeColumnName(entry.getKey());
+                                if (normalized != null && entry.getValue() != null) {
+                                        flags.put(normalized, entry.getValue());
+                                }
+                        }
+                }
+
+                Connection con = null;
+                PreparedStatement pstm = null;
+                try {
+                        con = L1DatabaseFactory.getInstance().getConnection();
+                        pstm = con.prepareStatement(
+                                        "INSERT INTO mapids (mapid, locationname, startX, endX, startY, endY, monster_amount, drop_rate, unique_rate, underwater, markable, teleportable, escapable, resurrection, painwand, penalty, take_pets, recall_pets, usable_item, usable_skill) "
+                                                        + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+                                                        + "ON DUPLICATE KEY UPDATE locationname = VALUES(locationname), startX = VALUES(startX), endX = VALUES(endX), startY = VALUES(startY), endY = VALUES(endY), monster_amount = VALUES(monster_amount), drop_rate = VALUES(drop_rate), unique_rate = VALUES(unique_rate), underwater = VALUES(underwater), markable = VALUES(markable), teleportable = VALUES(teleportable), escapable = VALUES(escapable), resurrection = VALUES(resurrection), painwand = VALUES(painwand), penalty = VALUES(penalty), take_pets = VALUES(take_pets), recall_pets = VALUES(recall_pets), usable_item = VALUES(usable_item), usable_skill = VALUES(usable_skill)");
+                        int idx = 1;
+                        pstm.setInt(idx++, mapId);
+                        pstm.setString(idx++, locationName);
+                        pstm.setInt(idx++, startX);
+                        pstm.setInt(idx++, endX);
+                        pstm.setInt(idx++, startY);
+                        pstm.setInt(idx++, endY);
+                        pstm.setDouble(idx++, 1d);
+                        pstm.setDouble(idx++, 1d);
+                        pstm.setInt(idx++, 1);
+                        for (String alias : COLUMN_ALIASES.keySet()) {
+                                String column = COLUMN_ALIASES.get(alias);
+                                boolean value = Boolean.TRUE.equals(flags.get(column));
+                                pstm.setBoolean(idx++, value);
+                        }
+                        pstm.executeUpdate();
+                } finally {
+                        SQLUtil.close(pstm);
+                        SQLUtil.close(con);
+                }
+        }
+
+        public static boolean updateBooleanFlag(int mapId, String column, boolean value) {
+                String normalized = normalizeColumnName(column);
+                if (normalized == null) {
+                        return false;
+                }
+                Connection con = null;
+                PreparedStatement pstm = null;
+                try {
+                        con = L1DatabaseFactory.getInstance().getConnection();
+                        pstm = con.prepareStatement("UPDATE mapids SET " + normalized + " = ? WHERE mapid = ?");
+                        pstm.setBoolean(1, value);
+                        pstm.setInt(2, mapId);
+                        return pstm.executeUpdate() > 0;
+                } catch (SQLException e) {
+                        _log.error(e.getLocalizedMessage(), e);
+                        return false;
+                } finally {
+                        SQLUtil.close(pstm);
+                        SQLUtil.close(con);
+                }
+        }
+
+        public static boolean mapExists(int mapId) {
+                Connection con = null;
+                PreparedStatement pstm = null;
+                ResultSet rs = null;
+                try {
+                        con = L1DatabaseFactory.getInstance().getConnection();
+                        pstm = con.prepareStatement("SELECT 1 FROM mapids WHERE mapid = ?");
+                        pstm.setInt(1, mapId);
+                        rs = pstm.executeQuery();
+                        return rs.next();
+                } catch (SQLException e) {
+                        _log.error(e.getLocalizedMessage(), e);
+                } finally {
+                        SQLUtil.close(rs);
+                        SQLUtil.close(pstm);
+                        SQLUtil.close(con);
+                }
+                return false;
+        }
+}

--- a/src/l1j/server/server/datatables/MapsTable.java
+++ b/src/l1j/server/server/datatables/MapsTable.java
@@ -73,11 +73,11 @@ public final class MapsTable {
 	 * Teleport whether the flag map reading from the database, HashMap _maps
 	 * stored.
 	 */
-	private void loadMapsFromDatabase() {
-		Connection con = null;
-		PreparedStatement pstm = null;
-		ResultSet rs = null;
-		try {
+        private void loadMapsFromDatabase() {
+                Connection con = null;
+                PreparedStatement pstm = null;
+                ResultSet rs = null;
+                try {
 			con = L1DatabaseFactory.getInstance().getConnection();
 			pstm = con.prepareStatement("SELECT * FROM mapids");
 			for (rs = pstm.executeQuery(); rs.next();) {
@@ -110,8 +110,50 @@ public final class MapsTable {
 			SQLUtil.close(rs);
 			SQLUtil.close(pstm);
 			SQLUtil.close(con);
-		}
-	}
+                }
+        }
+
+        public synchronized void reload(int mapId) {
+                Connection con = null;
+                PreparedStatement pstm = null;
+                ResultSet rs = null;
+                try {
+                        con = L1DatabaseFactory.getInstance().getConnection();
+                        pstm = con.prepareStatement("SELECT * FROM mapids WHERE mapid = ?");
+                        pstm.setInt(1, mapId);
+                        rs = pstm.executeQuery();
+                        if (rs.next()) {
+                                MapData data = new MapData();
+                                data.locationname = rs.getString("locationname");
+                                data.startX = rs.getInt("startX");
+                                data.endX = rs.getInt("endX");
+                                data.startY = rs.getInt("startY");
+                                data.endY = rs.getInt("endY");
+                                data.monster_amount = rs.getDouble("monster_amount");
+                                data.dropRate = rs.getDouble("drop_rate");
+                                data.isUnderwater = rs.getBoolean("underwater");
+                                data.markable = rs.getBoolean("markable");
+                                data.teleportable = rs.getBoolean("teleportable");
+                                data.escapable = rs.getBoolean("escapable");
+                                data.isUseResurrection = rs.getBoolean("resurrection");
+                                data.isUsePainwand = rs.getBoolean("painwand");
+                                data.isEnabledDeathPenalty = rs.getBoolean("penalty");
+                                data.isTakePets = rs.getBoolean("take_pets");
+                                data.isRecallPets = rs.getBoolean("recall_pets");
+                                data.isUsableItem = rs.getBoolean("usable_item");
+                                data.isUsableSkill = rs.getBoolean("usable_skill");
+                                _maps.put(mapId, data);
+                        } else {
+                                _maps.remove(mapId);
+                        }
+                } catch (SQLException e) {
+                        _log.error(e.getLocalizedMessage(), e);
+                } finally {
+                        SQLUtil.close(rs);
+                        SQLUtil.close(pstm);
+                        SQLUtil.close(con);
+                }
+        }
 
 	/**
 	 * MapsTable Instances of return.

--- a/src/l1j/server/server/model/map/L1WorldMap.java
+++ b/src/l1j/server/server/model/map/L1WorldMap.java
@@ -18,6 +18,7 @@
  */
 package l1j.server.server.model.map;
 
+import java.io.IOException;
 import java.util.Map;
 
 import org.slf4j.Logger;
@@ -58,11 +59,25 @@ public class L1WorldMap {
 	/**
 	 * The map information to hold L1Map returns.
 	 */
-	public L1Map getMap(short mapId) {
-		L1Map map = _maps.get((int) mapId);
-		if (map == null) {
-			map = L1Map.newNull();
-		}
-		return map;
-	}
+        public L1Map getMap(short mapId) {
+                L1Map map = _maps.get((int) mapId);
+                if (map == null) {
+                        map = L1Map.newNull();
+                }
+                return map;
+        }
+
+        public synchronized void reloadMap(int mapId) {
+                try {
+                        L1Map map = MapReader.getDefaultReader().read(mapId);
+                        if (map != null) {
+                                _maps.put(mapId, map);
+                        } else {
+                                _maps.remove(mapId);
+                        }
+                } catch (IOException e) {
+                        _log.error(e.getLocalizedMessage(), e);
+                }
+        }
 }
+


### PR DESCRIPTION
## Summary
- extend the `.map` GM command with `new` to create fresh map files and `meta set` to edit map flags without leaving the client
- add `MapIdsTableEditor` helpers plus a `MapsTable.reload` path to upsert `mapids` rows and keep metadata caches synchronized
- teach `L1WorldMap` how to reload single maps so newly created or updated areas become immediately available

## Testing
- not run (ant command not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e15b0f688c8332baf5a04538a2b51c