### PR TITLE
Add atomic tile reload helper

### DIFF
--- a/src/l1j/server/server/model/map/L1V1Map.java
+++ b/src/l1j/server/server/model/map/L1V1Map.java
@@ -98,25 +98,57 @@ public class L1V1Map extends L1Map {
 		_isUsableSkill = usableSkill;
 	}
 
-	public L1V1Map(L1V1Map map) {
-		_mapId = map._mapId;
+        public L1V1Map(L1V1Map map) {
+                _mapId = map._mapId;
 
-		_map = new byte[map._map.length][];
-		for (int i = 0; i < map._map.length; i++) {
-			_map[i] = map._map[i].clone();
-		}
+                _map = new byte[map._map.length][];
+                for (int i = 0; i < map._map.length; i++) {
+                        _map[i] = map._map[i].clone();
+                }
 
-		_worldTopLeftX = map._worldTopLeftX;
-		_worldTopLeftY = map._worldTopLeftY;
-		_worldBottomRightX = map._worldBottomRightX;
-		_worldBottomRightY = map._worldBottomRightY;
+                _worldTopLeftX = map._worldTopLeftX;
+                _worldTopLeftY = map._worldTopLeftY;
+                _worldBottomRightX = map._worldBottomRightX;
+                _worldBottomRightY = map._worldBottomRightY;
 
-	}
+        }
 
-	private int accessTile(int x, int y) {
-		if (!isInMap(x, y)) {
-			return 0;
-		}
+        public void applyFrom(L1V1Map source) {
+                if (source == null) {
+                        throw new IllegalArgumentException("source");
+                }
+
+                byte[][] newTiles = new byte[source._map.length][];
+                for (int i = 0; i < source._map.length; i++) {
+                        byte[] row = source._map[i];
+                        newTiles[i] = row != null ? row.clone() : null;
+                }
+
+                _map = newTiles;
+
+                _mapId = source._mapId;
+                _worldTopLeftX = source._worldTopLeftX;
+                _worldTopLeftY = source._worldTopLeftY;
+                _worldBottomRightX = source._worldBottomRightX;
+                _worldBottomRightY = source._worldBottomRightY;
+
+                _isUnderwater = source._isUnderwater;
+                _isMarkable = source._isMarkable;
+                _isTeleportable = source._isTeleportable;
+                _isEscapable = source._isEscapable;
+                _isUseResurrection = source._isUseResurrection;
+                _isUsePainwand = source._isUsePainwand;
+                _isEnabledDeathPenalty = source._isEnabledDeathPenalty;
+                _isTakePets = source._isTakePets;
+                _isRecallPets = source._isRecallPets;
+                _isUsableItem = source._isUsableItem;
+                _isUsableSkill = source._isUsableSkill;
+        }
+
+        private int accessTile(int x, int y) {
+                if (!isInMap(x, y)) {
+                        return 0;
+                }
 
 		return _map[x - _worldTopLeftX][y - _worldTopLeftY];
 	}


### PR DESCRIPTION
## Summary
- add an `applyFrom` helper to `L1V1Map` that clones tile rows into a temporary array before publishing
- ensure map coordinates and flags are updated only after the new tile array is fully initialized

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e163ef37dc83328e3979cbebc2952b