### PR TITLE
Extend map editor for metadata and map lifecycle

### DIFF
--- a/src/l1j/server/server/command/executor/L1MapEditor.java
+++ b/src/l1j/server/server/command/executor/L1MapEditor.java
@@ -4,11 +4,18 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Consumer;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import l1j.server.server.datatables.MapIdsTableEditor;
+import l1j.server.server.datatables.MapIdsTableEditor.MapMetadata;
+import l1j.server.server.datatables.MapsTable;
 import l1j.server.server.model.Instance.L1PcInstance;
 import l1j.server.server.model.map.edit.MapEditManager;
 import l1j.server.server.model.map.edit.MapEditOperation;
@@ -16,7 +23,9 @@ import l1j.server.server.model.map.edit.MapEditSession;
 import l1j.server.server.model.map.edit.MapEditSession.BrushMode;
 import l1j.server.server.model.map.edit.MapEditSession.TileChangeSummary;
 import l1j.server.server.model.map.edit.MapEditSession.ZoneSetting;
+import l1j.server.server.model.map.L1WorldMap;
 import l1j.server.server.serverpackets.S_SystemMessage;
+import l1j.server.server.utils.MapEditorIOUtils;
 
 public class L1MapEditor implements L1CommandExecutor {
 
@@ -52,6 +61,12 @@ public class L1MapEditor implements L1CommandExecutor {
                         case "start":
                                 handleStart(pc, manager);
                                 break;
+                        case "new":
+                                handleNew(pc, manager, parts);
+                                break;
+                        case "meta":
+                                handleMeta(pc, manager, parts);
+                                break;
                         case "brush":
                                 handleBrush(pc, manager, parts);
                                 break;
@@ -71,7 +86,11 @@ public class L1MapEditor implements L1CommandExecutor {
                                 handlePreview(pc, manager);
                                 break;
                         case "commit":
-                                handleCommit(pc, manager);
+                        case "save":
+                                handleSave(pc, manager);
+                                break;
+                        case "revert":
+                                handleRevert(pc, manager, parts);
                                 break;
                         case "cancel":
                                 handleCancel(pc, manager);
@@ -98,6 +117,302 @@ public class L1MapEditor implements L1CommandExecutor {
                         pc.sendPackets(new S_SystemMessage("Pending edits: " + session.getPendingChangeCount()));
                 }
                 pc.sendPackets(new S_SystemMessage("Brush: " + session.describeBrush()));
+        }
+
+        private void handleNew(L1PcInstance pc, MapEditManager manager, String[] parts) {
+                if (parts.length < 6) {
+                        pc.sendPackets(new S_SystemMessage(
+                                        "Usage: .map new <mapId> <startX> <startY> <width> <height> [name=<text>] [monster=<amount>] [drop=<rate>] [+flag|-flag ...] [tile=<id>]"));
+                        return;
+                }
+                short mapId;
+                int startX;
+                int startY;
+                int width;
+                int height;
+                try {
+                        mapId = Short.parseShort(parts[1]);
+                        startX = Integer.parseInt(parts[2]);
+                        startY = Integer.parseInt(parts[3]);
+                        width = Integer.parseInt(parts[4]);
+                        height = Integer.parseInt(parts[5]);
+                } catch (NumberFormatException ex) {
+                        pc.sendPackets(new S_SystemMessage("Invalid map id or dimensions."));
+                        return;
+                }
+                if (width <= 0 || height <= 0) {
+                        pc.sendPackets(new S_SystemMessage("Width and height must be positive."));
+                        return;
+                }
+
+                MapIdsTableEditor editor = MapIdsTableEditor.getInstance();
+                MapMetadata existing;
+                try {
+                        existing = editor.load(mapId);
+                } catch (RuntimeException ex) {
+                        _log.warn("Unable to check map metadata", ex);
+                        pc.sendPackets(new S_SystemMessage("Failed to query existing map metadata: " + ex.getMessage()));
+                        return;
+                }
+                if (existing != null) {
+                        pc.sendPackets(new S_SystemMessage("Map " + mapId + " already exists. Use .map meta set to update."));
+                        return;
+                }
+
+                int endX = startX + width - 1;
+                int endY = startY + height - 1;
+                Map<String, String> values = parseKeyValueArgs(parts, 6);
+                Map<String, Boolean> flags = parseBooleanFlags(parts, 6);
+
+                MapMetadata metadata = new MapMetadata(mapId);
+                metadata.setLocationName(values.getOrDefault("name", "Map " + mapId));
+                metadata.setStartX(startX);
+                metadata.setEndX(endX);
+                metadata.setStartY(startY);
+                metadata.setEndY(endY);
+
+                String monsterValue = getOption(values, "monster", "monsters", "monster_amount");
+                if (monsterValue != null) {
+                        try {
+                                metadata.setMonsterAmount(Double.parseDouble(monsterValue));
+                        } catch (NumberFormatException ex) {
+                                pc.sendPackets(new S_SystemMessage("Invalid monster amount: " + monsterValue));
+                                return;
+                        }
+                }
+
+                String dropValue = getOption(values, "drop", "drop_rate", "droprate");
+                if (dropValue != null) {
+                        try {
+                                metadata.setDropRate(Double.parseDouble(dropValue));
+                        } catch (NumberFormatException ex) {
+                                pc.sendPackets(new S_SystemMessage("Invalid drop rate: " + dropValue));
+                                return;
+                        }
+                }
+
+                metadata.setUnderwater(getFlag(flags, "underwater", false));
+                metadata.setMarkable(getFlag(flags, "markable", false));
+                metadata.setTeleportable(getFlag(flags, "teleportable", false));
+                metadata.setEscapable(getFlag(flags, "escapable", false));
+                metadata.setUseResurrection(getFlag(flags, "resurrection", false));
+                metadata.setUsePainwand(getFlag(flags, "painwand", false));
+                metadata.setEnabledDeathPenalty(getFlag(flags, "penalty", false));
+                metadata.setTakePets(getFlag(flags, "take_pets", false));
+                metadata.setRecallPets(getFlag(flags, "recall_pets", false));
+                metadata.setUsableItem(getFlag(flags, "usable_item", false));
+                metadata.setUsableSkill(getFlag(flags, "usable_skill", false));
+
+                try {
+                        editor.save(metadata);
+                        MapsTable.getInstance().reload();
+                } catch (RuntimeException ex) {
+                        _log.warn("Unable to save map metadata", ex);
+                        pc.sendPackets(new S_SystemMessage("Failed to write map metadata: " + ex.getMessage()));
+                        return;
+                }
+
+                int defaultTile = 0;
+                String tileValue = values.get("tile");
+                if (tileValue != null) {
+                        try {
+                                defaultTile = Integer.parseInt(tileValue);
+                                if (defaultTile < 0 || defaultTile > 255) {
+                                        pc.sendPackets(new S_SystemMessage("Tile id must be between 0 and 255."));
+                                        return;
+                                }
+                        } catch (NumberFormatException ex) {
+                                pc.sendPackets(new S_SystemMessage("Invalid tile id: " + tileValue));
+                                return;
+                        }
+                }
+
+                try {
+                        MapEditorIOUtils.writeBlankMap(mapId, width, height, defaultTile);
+                } catch (IOException ex) {
+                        _log.error("Failed to create map file", ex);
+                        pc.sendPackets(new S_SystemMessage("Failed to write map file: " + ex.getMessage()));
+                        return;
+                }
+
+                refreshLiveMap(mapId);
+                pc.sendPackets(new S_SystemMessage(
+                                "Created map " + mapId + " with size " + width + "x" + height + ". Metadata saved."));
+                MapEditSession session = manager.getSession(pc);
+                if (session != null && session.getMapId() == mapId) {
+                        manager.cancelSession(pc);
+                        pc.sendPackets(new S_SystemMessage(
+                                        "Existing editing session reset. Use .map start on the new map to edit tiles."));
+                }
+        }
+
+        private void handleMeta(L1PcInstance pc, MapEditManager manager, String[] parts) {
+                if (parts.length < 2) {
+                        pc.sendPackets(new S_SystemMessage("Usage: .map meta set <mapId> [options]"));
+                        return;
+                }
+                String sub = parts[1].toLowerCase(Locale.ENGLISH);
+                switch (sub) {
+                case "set":
+                        handleMetaSet(pc, manager, parts);
+                        break;
+                default:
+                        pc.sendPackets(new S_SystemMessage("Usage: .map meta set <mapId> [options]"));
+                        break;
+                }
+        }
+
+        private void handleMetaSet(L1PcInstance pc, MapEditManager manager, String[] parts) {
+                if (parts.length < 3) {
+                        pc.sendPackets(new S_SystemMessage(
+                                        "Usage: .map meta set <mapId> [name=<text>] [startX=<value>] [startY=<value>] [endX=<value>] [endY=<value>] [width=<value>] [height=<value>] [monster=<amount>] [drop=<rate>] [+flag|-flag ...]"));
+                        return;
+                }
+                int mapId;
+                try {
+                        mapId = Integer.parseInt(parts[2]);
+                } catch (NumberFormatException ex) {
+                        pc.sendPackets(new S_SystemMessage("Invalid map id."));
+                        return;
+                }
+
+                MapIdsTableEditor editor = MapIdsTableEditor.getInstance();
+                MapMetadata metadata;
+                try {
+                        metadata = editor.load(mapId);
+                } catch (RuntimeException ex) {
+                        _log.warn("Unable to load map metadata", ex);
+                        pc.sendPackets(new S_SystemMessage("Failed to load map metadata: " + ex.getMessage()));
+                        return;
+                }
+                if (metadata == null) {
+                        pc.sendPackets(new S_SystemMessage("Map " + mapId + " does not exist. Use .map new to create it."));
+                        return;
+                }
+
+                Map<String, String> values = parseKeyValueArgs(parts, 3);
+                Map<String, Boolean> flags = parseBooleanFlags(parts, 3);
+                boolean changed = false;
+
+                String name = values.get("name");
+                if (name != null && !name.equals(metadata.getLocationName())) {
+                        metadata.setLocationName(name);
+                        changed = true;
+                }
+
+                try {
+                        changed |= updateCoordinate(values, metadata, "startx");
+                        changed |= updateCoordinate(values, metadata, "starty");
+                        changed |= updateCoordinate(values, metadata, "endx");
+                        changed |= updateCoordinate(values, metadata, "endy");
+                } catch (IllegalArgumentException ex) {
+                        pc.sendPackets(new S_SystemMessage(ex.getMessage()));
+                        return;
+                }
+
+                String widthValue = values.get("width");
+                if (widthValue != null) {
+                        try {
+                                int width = Integer.parseInt(widthValue);
+                                if (width <= 0) {
+                                        throw new NumberFormatException();
+                                }
+                                int endX = metadata.getStartX() + width - 1;
+                                if (endX != metadata.getEndX()) {
+                                        metadata.setEndX(endX);
+                                        changed = true;
+                                }
+                        } catch (NumberFormatException ex) {
+                                pc.sendPackets(new S_SystemMessage("Invalid width: " + widthValue));
+                                return;
+                        }
+                }
+
+                String heightValue = values.get("height");
+                if (heightValue != null) {
+                        try {
+                                int height = Integer.parseInt(heightValue);
+                                if (height <= 0) {
+                                        throw new NumberFormatException();
+                                }
+                                int endY = metadata.getStartY() + height - 1;
+                                if (endY != metadata.getEndY()) {
+                                        metadata.setEndY(endY);
+                                        changed = true;
+                                }
+                        } catch (NumberFormatException ex) {
+                                pc.sendPackets(new S_SystemMessage("Invalid height: " + heightValue));
+                                return;
+                        }
+                }
+
+                String monsterValue = getOption(values, "monster", "monsters", "monster_amount");
+                if (monsterValue != null) {
+                        try {
+                                double monsterAmount = Double.parseDouble(monsterValue);
+                                if (monsterAmount != metadata.getMonsterAmount()) {
+                                        metadata.setMonsterAmount(monsterAmount);
+                                        changed = true;
+                                }
+                        } catch (NumberFormatException ex) {
+                                pc.sendPackets(new S_SystemMessage("Invalid monster amount: " + monsterValue));
+                                return;
+                        }
+                }
+
+                String dropValue = getOption(values, "drop", "drop_rate", "droprate");
+                if (dropValue != null) {
+                        try {
+                                double dropRate = Double.parseDouble(dropValue);
+                                if (dropRate != metadata.getDropRate()) {
+                                        metadata.setDropRate(dropRate);
+                                        changed = true;
+                                }
+                        } catch (NumberFormatException ex) {
+                                pc.sendPackets(new S_SystemMessage("Invalid drop rate: " + dropValue));
+                                return;
+                        }
+                }
+
+                changed |= applyFlag(metadata::setUnderwater, metadata.isUnderwater(), flags, "underwater");
+                changed |= applyFlag(metadata::setMarkable, metadata.isMarkable(), flags, "markable");
+                changed |= applyFlag(metadata::setTeleportable, metadata.isTeleportable(), flags, "teleportable");
+                changed |= applyFlag(metadata::setEscapable, metadata.isEscapable(), flags, "escapable");
+                changed |= applyFlag(metadata::setUseResurrection, metadata.isUseResurrection(), flags, "resurrection");
+                changed |= applyFlag(metadata::setUsePainwand, metadata.isUsePainwand(), flags, "painwand");
+                changed |= applyFlag(metadata::setEnabledDeathPenalty, metadata.isEnabledDeathPenalty(), flags, "penalty");
+                changed |= applyFlag(metadata::setTakePets, metadata.isTakePets(), flags, "take_pets");
+                changed |= applyFlag(metadata::setRecallPets, metadata.isRecallPets(), flags, "recall_pets");
+                changed |= applyFlag(metadata::setUsableItem, metadata.isUsableItem(), flags, "usable_item");
+                changed |= applyFlag(metadata::setUsableSkill, metadata.isUsableSkill(), flags, "usable_skill");
+
+                if (!changed) {
+                        pc.sendPackets(new S_SystemMessage("No metadata changes detected."));
+                        return;
+                }
+
+                if (metadata.getEndX() < metadata.getStartX() || metadata.getEndY() < metadata.getStartY()) {
+                        pc.sendPackets(new S_SystemMessage("Invalid coordinates: end must be greater than or equal to start."));
+                        return;
+                }
+
+                try {
+                        editor.save(metadata);
+                        MapsTable.getInstance().reload();
+                } catch (RuntimeException ex) {
+                        _log.warn("Unable to save map metadata", ex);
+                        pc.sendPackets(new S_SystemMessage("Failed to save metadata: " + ex.getMessage()));
+                        return;
+                }
+
+                refreshLiveMap((short) mapId);
+                MapEditSession session = manager.getSession(pc);
+                if (session != null && session.getMapId() == mapId) {
+                        manager.cancelSession(pc);
+                        pc.sendPackets(new S_SystemMessage(
+                                        "Active editing session reset to pick up new metadata. Use .map start to resume."));
+                }
+                pc.sendPackets(new S_SystemMessage("Updated metadata for map " + mapId + "."));
         }
 
         private void handleBrush(L1PcInstance pc, MapEditManager manager, String[] parts) {
@@ -283,22 +598,60 @@ public class L1MapEditor implements L1CommandExecutor {
                 }
         }
 
-        private void handleCommit(L1PcInstance pc, MapEditManager manager) {
+        private void handleSave(L1PcInstance pc, MapEditManager manager) {
                 MapEditSession session = requireSession(pc, manager);
                 if (session == null) {
                         return;
                 }
                 if (!session.hasPendingChanges()) {
-                        pc.sendPackets(new S_SystemMessage("No pending edits to commit."));
+                        pc.sendPackets(new S_SystemMessage("No pending edits to save."));
                         return;
                 }
                 try {
                         int committed = session.commit();
-                        pc.sendPackets(new S_SystemMessage("Committed " + committed + " tile(s) to map " + session.getMapId() + "."));
+                        refreshLiveMap(session.getMapId());
+                        pc.sendPackets(new S_SystemMessage("Saved " + committed + " tile(s) to map " + session.getMapId() + "."));
                 } catch (IOException e) {
-                        _log.error("Failed to commit map edits", e);
-                        pc.sendPackets(new S_SystemMessage("Failed to commit edits: " + e.getMessage()));
+                        _log.error("Failed to save map edits", e);
+                        pc.sendPackets(new S_SystemMessage("Failed to save edits: " + e.getMessage()));
                 }
+        }
+
+        private void handleRevert(L1PcInstance pc, MapEditManager manager, String[] parts) {
+                MapEditSession session = manager.getSession(pc);
+                short mapId;
+                if (parts.length >= 2) {
+                        try {
+                                mapId = Short.parseShort(parts[1]);
+                        } catch (NumberFormatException ex) {
+                                pc.sendPackets(new S_SystemMessage("Invalid map id."));
+                                return;
+                        }
+                } else if (session != null) {
+                        mapId = session.getMapId();
+                } else {
+                        pc.sendPackets(new S_SystemMessage("Specify a map id or start an editing session first."));
+                        return;
+                }
+
+                try {
+                        if (!MapEditorIOUtils.restoreBackup(mapId)) {
+                                pc.sendPackets(new S_SystemMessage("No backup exists for map " + mapId + "."));
+                                return;
+                        }
+                } catch (IOException e) {
+                        _log.error("Failed to restore map backup", e);
+                        pc.sendPackets(new S_SystemMessage("Failed to restore backup: " + e.getMessage()));
+                        return;
+                }
+
+                if (session != null && session.getMapId() == mapId) {
+                        manager.cancelSession(pc);
+                        pc.sendPackets(
+                                        new S_SystemMessage("Editing session reset to match restored map state."));
+                }
+                refreshLiveMap(mapId);
+                pc.sendPackets(new S_SystemMessage("Restored map " + mapId + " from backup."));
         }
 
         private void handleCancel(L1PcInstance pc, MapEditManager manager) {
@@ -322,7 +675,7 @@ public class L1MapEditor implements L1CommandExecutor {
 
         private void sendHelp(L1PcInstance pc) {
                 pc.sendPackets(new S_SystemMessage(
-                                ".map <start|brush|mode|apply|undo|redo|preview|commit|cancel>"));
+                                ".map <start|new|meta|brush|mode|apply|undo|redo|preview|save|commit|revert|cancel>"));
         }
 
         private ZoneSetting parseZone(String value) {
@@ -362,5 +715,136 @@ public class L1MapEditor implements L1CommandExecutor {
                 default:
                         return BrushMode.SINGLE;
                 }
+        }
+
+        private Map<String, String> parseKeyValueArgs(String[] parts, int startIndex) {
+                Map<String, String> values = new HashMap<>();
+                for (int i = startIndex; i < parts.length; i++) {
+                        String token = parts[i];
+                        if (token == null || token.isEmpty()) {
+                                continue;
+                        }
+                        if (token.startsWith("+") || token.startsWith("-")) {
+                                continue;
+                        }
+                        int idx = token.indexOf('=');
+                        if (idx <= 0 || idx >= token.length() - 1) {
+                                continue;
+                        }
+                        String key = token.substring(0, idx).toLowerCase(Locale.ENGLISH);
+                        String value = token.substring(idx + 1);
+                        values.put(key, value);
+                }
+                return values;
+        }
+
+        private Map<String, Boolean> parseBooleanFlags(String[] parts, int startIndex) {
+                Map<String, Boolean> flags = new HashMap<>();
+                for (int i = startIndex; i < parts.length; i++) {
+                        String token = parts[i];
+                        if (token == null || token.length() < 2) {
+                                continue;
+                        }
+                        char prefix = token.charAt(0);
+                        if (prefix != '+' && prefix != '-') {
+                                continue;
+                        }
+                        String flagName = token.substring(1).toLowerCase(Locale.ENGLISH);
+                        if (flagName.isEmpty()) {
+                                continue;
+                        }
+                        flags.put(flagName, prefix == '+');
+                }
+                return flags;
+        }
+
+        private boolean getFlag(Map<String, Boolean> flags, String key, boolean defaultValue) {
+                Boolean value = flags.get(key);
+                return value != null ? value.booleanValue() : defaultValue;
+        }
+
+        private String getOption(Map<String, String> values, String... keys) {
+                for (String key : keys) {
+                        String value = values.get(key);
+                        if (value != null) {
+                                return value;
+                        }
+                }
+                return null;
+        }
+
+        private boolean updateCoordinate(Map<String, String> values, MapMetadata metadata, String key) {
+                String value = values.get(key);
+                if (value == null) {
+                        return false;
+                }
+                try {
+                        int coordinate = Integer.parseInt(value);
+                        switch (key) {
+                        case "startx":
+                                if (coordinate != metadata.getStartX()) {
+                                        metadata.setStartX(coordinate);
+                                        return true;
+                                }
+                                break;
+                        case "endx":
+                                if (coordinate != metadata.getEndX()) {
+                                        metadata.setEndX(coordinate);
+                                        return true;
+                                }
+                                break;
+                        case "starty":
+                                if (coordinate != metadata.getStartY()) {
+                                        metadata.setStartY(coordinate);
+                                        return true;
+                                }
+                                break;
+                        case "endy":
+                                if (coordinate != metadata.getEndY()) {
+                                        metadata.setEndY(coordinate);
+                                        return true;
+                                }
+                                break;
+                        default:
+                                break;
+                        }
+                        return false;
+                } catch (NumberFormatException ex) {
+                        String label;
+                        switch (key) {
+                        case "startx":
+                                label = "startX";
+                                break;
+                        case "endx":
+                                label = "endX";
+                                break;
+                        case "starty":
+                                label = "startY";
+                                break;
+                        case "endy":
+                                label = "endY";
+                                break;
+                        default:
+                                label = key;
+                                break;
+                        }
+                        throw new IllegalArgumentException("Invalid " + label + ": " + value, ex);
+                }
+        }
+
+        private boolean applyFlag(Consumer<Boolean> setter, boolean currentValue, Map<String, Boolean> flags, String key) {
+                Boolean value = flags.get(key);
+                if (value == null) {
+                        return false;
+                }
+                if (value.booleanValue() != currentValue) {
+                        setter.accept(value);
+                        return true;
+                }
+                return false;
+        }
+
+        private void refreshLiveMap(short mapId) {
+                L1WorldMap.getInstance().reloadMap(mapId);
         }
 }

--- a/src/l1j/server/server/datatables/MapIdsTableEditor.java
+++ b/src/l1j/server/server/datatables/MapIdsTableEditor.java
@@ -1,0 +1,284 @@
+package l1j.server.server.datatables;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import l1j.server.L1DatabaseFactory;
+import l1j.server.server.utils.SQLUtil;
+
+public class MapIdsTableEditor {
+
+        public static class MapMetadata {
+                private final int mapId;
+                private String locationName;
+                private int startX;
+                private int endX;
+                private int startY;
+                private int endY;
+                private double monsterAmount = 1.0d;
+                private double dropRate = 1.0d;
+                private boolean underwater;
+                private boolean markable;
+                private boolean teleportable;
+                private boolean escapable;
+                private boolean useResurrection;
+                private boolean usePainwand;
+                private boolean enabledDeathPenalty;
+                private boolean takePets;
+                private boolean recallPets;
+                private boolean usableItem;
+                private boolean usableSkill;
+
+                public MapMetadata(int mapId) {
+                        this.mapId = mapId;
+                }
+
+                public int getMapId() {
+                        return mapId;
+                }
+
+                public String getLocationName() {
+                        return locationName;
+                }
+
+                public void setLocationName(String locationName) {
+                        this.locationName = locationName;
+                }
+
+                public int getStartX() {
+                        return startX;
+                }
+
+                public void setStartX(int startX) {
+                        this.startX = startX;
+                }
+
+                public int getEndX() {
+                        return endX;
+                }
+
+                public void setEndX(int endX) {
+                        this.endX = endX;
+                }
+
+                public int getStartY() {
+                        return startY;
+                }
+
+                public void setStartY(int startY) {
+                        this.startY = startY;
+                }
+
+                public int getEndY() {
+                        return endY;
+                }
+
+                public void setEndY(int endY) {
+                        this.endY = endY;
+                }
+
+                public double getMonsterAmount() {
+                        return monsterAmount;
+                }
+
+                public void setMonsterAmount(double monsterAmount) {
+                        this.monsterAmount = monsterAmount;
+                }
+
+                public double getDropRate() {
+                        return dropRate;
+                }
+
+                public void setDropRate(double dropRate) {
+                        this.dropRate = dropRate;
+                }
+
+                public boolean isUnderwater() {
+                        return underwater;
+                }
+
+                public void setUnderwater(boolean underwater) {
+                        this.underwater = underwater;
+                }
+
+                public boolean isMarkable() {
+                        return markable;
+                }
+
+                public void setMarkable(boolean markable) {
+                        this.markable = markable;
+                }
+
+                public boolean isTeleportable() {
+                        return teleportable;
+                }
+
+                public void setTeleportable(boolean teleportable) {
+                        this.teleportable = teleportable;
+                }
+
+                public boolean isEscapable() {
+                        return escapable;
+                }
+
+                public void setEscapable(boolean escapable) {
+                        this.escapable = escapable;
+                }
+
+                public boolean isUseResurrection() {
+                        return useResurrection;
+                }
+
+                public void setUseResurrection(boolean useResurrection) {
+                        this.useResurrection = useResurrection;
+                }
+
+                public boolean isUsePainwand() {
+                        return usePainwand;
+                }
+
+                public void setUsePainwand(boolean usePainwand) {
+                        this.usePainwand = usePainwand;
+                }
+
+                public boolean isEnabledDeathPenalty() {
+                        return enabledDeathPenalty;
+                }
+
+                public void setEnabledDeathPenalty(boolean enabledDeathPenalty) {
+                        this.enabledDeathPenalty = enabledDeathPenalty;
+                }
+
+                public boolean isTakePets() {
+                        return takePets;
+                }
+
+                public void setTakePets(boolean takePets) {
+                        this.takePets = takePets;
+                }
+
+                public boolean isRecallPets() {
+                        return recallPets;
+                }
+
+                public void setRecallPets(boolean recallPets) {
+                        this.recallPets = recallPets;
+                }
+
+                public boolean isUsableItem() {
+                        return usableItem;
+                }
+
+                public void setUsableItem(boolean usableItem) {
+                        this.usableItem = usableItem;
+                }
+
+                public boolean isUsableSkill() {
+                        return usableSkill;
+                }
+
+                public void setUsableSkill(boolean usableSkill) {
+                        this.usableSkill = usableSkill;
+                }
+        }
+
+        private static final MapIdsTableEditor INSTANCE = new MapIdsTableEditor();
+
+        private MapIdsTableEditor() {
+        }
+
+        public static MapIdsTableEditor getInstance() {
+                        return INSTANCE;
+        }
+
+        public MapMetadata load(int mapId) {
+                Connection con = null;
+                PreparedStatement ps = null;
+                ResultSet rs = null;
+                try {
+                        con = L1DatabaseFactory.getInstance().getConnection();
+                        ps = con.prepareStatement("SELECT * FROM mapids WHERE mapid=?");
+                        ps.setInt(1, mapId);
+                        rs = ps.executeQuery();
+                        if (!rs.next()) {
+                                return null;
+                        }
+                        MapMetadata metadata = new MapMetadata(mapId);
+                        metadata.setLocationName(rs.getString("locationname"));
+                        metadata.setStartX(rs.getInt("startX"));
+                        metadata.setEndX(rs.getInt("endX"));
+                        metadata.setStartY(rs.getInt("startY"));
+                        metadata.setEndY(rs.getInt("endY"));
+                        metadata.setMonsterAmount(rs.getDouble("monster_amount"));
+                        metadata.setDropRate(rs.getDouble("drop_rate"));
+                        metadata.setUnderwater(rs.getBoolean("underwater"));
+                        metadata.setMarkable(rs.getBoolean("markable"));
+                        metadata.setTeleportable(rs.getBoolean("teleportable"));
+                        metadata.setEscapable(rs.getBoolean("escapable"));
+                        metadata.setUseResurrection(rs.getBoolean("resurrection"));
+                        metadata.setUsePainwand(rs.getBoolean("painwand"));
+                        metadata.setEnabledDeathPenalty(rs.getBoolean("penalty"));
+                        metadata.setTakePets(rs.getBoolean("take_pets"));
+                        metadata.setRecallPets(rs.getBoolean("recall_pets"));
+                        metadata.setUsableItem(rs.getBoolean("usable_item"));
+                        metadata.setUsableSkill(rs.getBoolean("usable_skill"));
+                        return metadata;
+                } catch (SQLException e) {
+                        throw new RuntimeException("Unable to load map metadata for map " + mapId, e);
+                } finally {
+                        SQLUtil.close(rs);
+                        SQLUtil.close(ps);
+                        SQLUtil.close(con);
+                }
+        }
+
+        public void save(MapMetadata metadata) {
+                Connection con = null;
+                PreparedStatement ps = null;
+                try {
+                        con = L1DatabaseFactory.getInstance().getConnection();
+                        ps = con.prepareStatement(
+                                        "UPDATE mapids SET locationname=?, startX=?, endX=?, startY=?, endY=?, monster_amount=?, drop_rate=?, underwater=?, markable=?, teleportable=?, escapable=?, resurrection=?, painwand=?, penalty=?, take_pets=?, recall_pets=?, usable_item=?, usable_skill=? WHERE mapid=?");
+                        bindMetadata(ps, metadata, 1);
+                        ps.setInt(19, metadata.getMapId());
+                        int updated = ps.executeUpdate();
+                        SQLUtil.close(ps);
+                        if (updated == 0) {
+                                ps = con.prepareStatement(
+                                                "INSERT INTO mapids (mapid, locationname, startX, endX, startY, endY, monster_amount, drop_rate, underwater, markable, teleportable, escapable, resurrection, painwand, penalty, take_pets, recall_pets, usable_item, usable_skill) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)");
+                                ps.setInt(1, metadata.getMapId());
+                                bindMetadata(ps, metadata, 2);
+                                ps.executeUpdate();
+                        }
+                } catch (SQLException e) {
+                        throw new RuntimeException("Unable to persist map metadata for map " + metadata.getMapId(), e);
+                } finally {
+                        SQLUtil.close(ps);
+                        SQLUtil.close(con);
+                }
+        }
+
+        private void bindMetadata(PreparedStatement ps, MapMetadata metadata, int startIndex) throws SQLException {
+                int i = startIndex;
+                ps.setString(i++, metadata.getLocationName());
+                ps.setInt(i++, metadata.getStartX());
+                ps.setInt(i++, metadata.getEndX());
+                ps.setInt(i++, metadata.getStartY());
+                ps.setInt(i++, metadata.getEndY());
+                ps.setDouble(i++, metadata.getMonsterAmount());
+                ps.setDouble(i++, metadata.getDropRate());
+                ps.setBoolean(i++, metadata.isUnderwater());
+                ps.setBoolean(i++, metadata.isMarkable());
+                ps.setBoolean(i++, metadata.isTeleportable());
+                ps.setBoolean(i++, metadata.isEscapable());
+                ps.setBoolean(i++, metadata.isUseResurrection());
+                ps.setBoolean(i++, metadata.isUsePainwand());
+                ps.setBoolean(i++, metadata.isEnabledDeathPenalty());
+                ps.setBoolean(i++, metadata.isTakePets());
+                ps.setBoolean(i++, metadata.isRecallPets());
+                ps.setBoolean(i++, metadata.isUsableItem());
+                ps.setBoolean(i++, metadata.isUsableSkill());
+        }
+}

--- a/src/l1j/server/server/datatables/MapsTable.java
+++ b/src/l1j/server/server/datatables/MapsTable.java
@@ -73,10 +73,11 @@ public final class MapsTable {
 	 * Teleport whether the flag map reading from the database, HashMap _maps
 	 * stored.
 	 */
-	private void loadMapsFromDatabase() {
-		Connection con = null;
-		PreparedStatement pstm = null;
-		ResultSet rs = null;
+        private synchronized void loadMapsFromDatabase() {
+                _maps.clear();
+                Connection con = null;
+                PreparedStatement pstm = null;
+                ResultSet rs = null;
 		try {
 			con = L1DatabaseFactory.getInstance().getConnection();
 			pstm = con.prepareStatement("SELECT * FROM mapids");
@@ -110,8 +111,12 @@ public final class MapsTable {
 			SQLUtil.close(rs);
 			SQLUtil.close(pstm);
 			SQLUtil.close(con);
-		}
-	}
+                }
+        }
+
+        public synchronized void reload() {
+                loadMapsFromDatabase();
+        }
 
 	/**
 	 * MapsTable Instances of return.

--- a/src/l1j/server/server/model/map/L1WorldMap.java
+++ b/src/l1j/server/server/model/map/L1WorldMap.java
@@ -18,6 +18,7 @@
  */
 package l1j.server.server.model.map;
 
+import java.io.IOException;
 import java.util.Map;
 
 import org.slf4j.Logger;
@@ -58,11 +59,23 @@ public class L1WorldMap {
 	/**
 	 * The map information to hold L1Map returns.
 	 */
-	public L1Map getMap(short mapId) {
-		L1Map map = _maps.get((int) mapId);
-		if (map == null) {
-			map = L1Map.newNull();
-		}
-		return map;
-	}
+        public L1Map getMap(short mapId) {
+                L1Map map = _maps.get((int) mapId);
+                if (map == null) {
+                        map = L1Map.newNull();
+                }
+                return map;
+        }
+
+        public synchronized void reloadMap(short mapId) {
+                try {
+                        MapReader reader = MapReader.getDefaultReader();
+                        L1Map map = reader.read(mapId);
+                        if (map != null) {
+                                _maps.put((int) mapId, map);
+                        }
+                } catch (IOException e) {
+                        _log.error("Failed to reload map " + mapId, e);
+                }
+        }
 }

--- a/src/l1j/server/server/model/map/edit/MapEditSession.java
+++ b/src/l1j/server/server/model/map/edit/MapEditSession.java
@@ -1,6 +1,5 @@
 package l1j.server.server.model.map.edit;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -16,7 +15,7 @@ import java.util.Set;
 
 import l1j.server.server.model.map.L1Map;
 import l1j.server.server.model.map.L1V1Map;
-import l1j.server.server.utils.FileUtil;
+import l1j.server.server.utils.MapEditorIOUtils;
 
 /**
  * Holds the editing state for a GM that is actively modifying a map. Sessions
@@ -425,13 +424,7 @@ public class MapEditSession {
                         sourceMap.setPassable(summary.getX(), summary.getY(), summary.isCurrentPassable());
                 }
 
-                String mapFilename = "./maps/" + mapId + ".txt";
-                File mapFile = new File(mapFilename);
-                if (mapFile.exists()) {
-                        File backupFile = new File(mapFilename + ".bak");
-                        FileUtil.copyFileUsingStream(mapFile, backupFile);
-                }
-                FileUtil.writeFile(mapFilename, sourceMap.toCsv());
+                MapEditorIOUtils.writeMapFile(mapId, sourceMap.toCsv(), true);
 
                 resetWorkingCopy();
                 return changedTiles;

--- a/src/l1j/server/server/utils/MapEditorIOUtils.java
+++ b/src/l1j/server/server/utils/MapEditorIOUtils.java
@@ -1,0 +1,101 @@
+package l1j.server.server.utils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+/**
+ * Helper functions used by the in-game map editor for persisting map files
+ * and managing their backups/caches.
+ */
+public final class MapEditorIOUtils {
+
+        private static final String MAP_DIR = "./maps/";
+        private static final String MAP_CACHE_DIR = "./data/mapcache/";
+
+        private MapEditorIOUtils() {
+        }
+
+        public static File getMapFile(short mapId) {
+                return new File(MAP_DIR + mapId + ".txt");
+        }
+
+        public static File getBackupFile(short mapId) {
+                return new File(MAP_DIR + mapId + ".txt.bak");
+        }
+
+        public static void writeMapFile(short mapId, String csvContent, boolean createBackup) throws IOException {
+                File mapFile = getMapFile(mapId);
+                ensureParentDirectory(mapFile.toPath());
+                if (createBackup && mapFile.exists()) {
+                        FileUtil.copyFileUsingStream(mapFile, getBackupFile(mapId));
+                }
+                FileUtil.writeFile(mapFile.getPath(), csvContent);
+                deleteMapCache(mapId);
+        }
+
+        public static void writeBlankMap(short mapId, int width, int height, int tileValue) throws IOException {
+                if (width <= 0 || height <= 0) {
+                        throw new IllegalArgumentException("width/height must be positive");
+                }
+                byte[][] tiles = new byte[width][height];
+                byte tile = (byte) tileValue;
+                for (int x = 0; x < width; x++) {
+                        Arrays.fill(tiles[x], tile);
+                }
+                writeTiles(mapId, tiles, false);
+        }
+
+        public static void writeTiles(short mapId, byte[][] tiles, boolean createBackup) throws IOException {
+                if (tiles == null || tiles.length == 0 || tiles[0].length == 0) {
+                        throw new IllegalArgumentException("tiles");
+                }
+                StringBuilder builder = new StringBuilder();
+                int width = tiles.length;
+                int height = tiles[0].length;
+                for (int y = 0; y < height; y++) {
+                        if (y > 0) {
+                                builder.append(System.lineSeparator());
+                        }
+                        for (int x = 0; x < width; x++) {
+                                if (x > 0) {
+                                        builder.append(',');
+                                }
+                                builder.append(tiles[x][y]);
+                        }
+                }
+                writeMapFile(mapId, builder.toString(), createBackup);
+        }
+
+        public static boolean restoreBackup(short mapId) throws IOException {
+                File backup = getBackupFile(mapId);
+                if (!backup.exists()) {
+                        return false;
+                }
+                File mapFile = getMapFile(mapId);
+                ensureParentDirectory(mapFile.toPath());
+                FileUtil.copyFileUsingStream(backup, mapFile);
+                deleteMapCache(mapId);
+                return true;
+        }
+
+        public static void deleteMapCache(short mapId) {
+                File cache = new File(MAP_CACHE_DIR + mapId + ".map");
+                if (cache.exists() && !cache.delete()) {
+                        cache.deleteOnExit();
+                }
+        }
+
+        private static void ensureParentDirectory(Path path) throws IOException {
+                Path parent = path.getParent();
+                if (parent == null) {
+                        return;
+                }
+                if (Files.exists(parent)) {
+                        return;
+                }
+                Files.createDirectories(parent);
+        }
+}


### PR DESCRIPTION
## Summary
- add .map new/meta/save/revert handling so GMs can create maps, edit metadata, and restore backups from the in-game editor
- add MapIdsTableEditor and MapEditorIOUtils utilities and reload hooks so map files, caches, and metadata stay synchronized with MapsTable/L1WorldMap

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1699095a48332afb2227d5b3b4c51