### PR TITLE
Add server-side target lock melee assist feature

### DIFF
--- a/config/altsettings.properties
+++ b/config/altsettings.properties
@@ -78,6 +78,13 @@ PolyEvent = False
 BossEvent = False
 # if you reset your server daily, you probably want to set this to false
 BossEventDailyReset = True
+
+# Enables the server-wide target lock melee assist system. When enabled, players can
+# lock on to monsters and automatically chase them for melee attacks.
+TargetLockAssistEnabled = False
+
+# Update frequency for the target lock melee assist monitor in milliseconds.
+TargetLockAssistInterval = 200
 # default of midnight. Must be in format of HH:mm where HH = 24 hour clock hours. NO AM/PM!
 BossEventDailyResetTime = 00:00
 

--- a/src/l1j/server/Config.java
+++ b/src/l1j/server/Config.java
@@ -177,9 +177,13 @@ public final class Config {
 	
 	public static boolean ENABLE_AUTO_QUEST_LEVEL30;
 	
-	public static boolean ENABLE_AUTO_QUEST_LEVEL50;
+public static boolean ENABLE_AUTO_QUEST_LEVEL50;
 
-	public static boolean RESTRICT_ACCOUNT_IPS;
+public static boolean ENABLE_TARGET_LOCK_ASSIST;
+
+public static int TARGET_LOCK_ASSIST_INTERVAL;
+
+public static boolean RESTRICT_ACCOUNT_IPS;
 
 	public static String RESTRICT_ACCOUNT_IPS_MESSAGE;
 
@@ -814,11 +818,13 @@ public final class Config {
 			ALT_BOSS_EVENT_DAILY_RESET = Boolean.parseBoolean(altSettings.getProperty("BossEventDailyReset", "False"));
 			ALT_BOSS_EVENT_RESET_TIME = altSettings.getProperty("BossEventDailyResetTime", "00:00");
 			ENABLE_AUTO_QUEST_LEVEL15 = Boolean.parseBoolean(altSettings.getProperty("EnableAutoQuestLevel15", "True"));
-			ENABLE_AUTO_QUEST_LEVEL30 = Boolean.parseBoolean(altSettings.getProperty("EnableAutoQuestLevel30", "True"));
-			ENABLE_AUTO_QUEST_LEVEL50 = Boolean.parseBoolean(altSettings.getProperty("EnableAutoQuestLevel50", "True"));
+                        ENABLE_AUTO_QUEST_LEVEL30 = Boolean.parseBoolean(altSettings.getProperty("EnableAutoQuestLevel30", "True"));
+                        ENABLE_AUTO_QUEST_LEVEL50 = Boolean.parseBoolean(altSettings.getProperty("EnableAutoQuestLevel50", "True"));
+                        ENABLE_TARGET_LOCK_ASSIST = Boolean.parseBoolean(altSettings.getProperty("TargetLockAssistEnabled", "False"));
+                        TARGET_LOCK_ASSIST_INTERVAL = Integer.parseInt(altSettings.getProperty("TargetLockAssistInterval", "200"));
 
-			
-			ALT_DAYS_LIMIT_PLEDGE_JOIN = TimeUnit.DAYS
+
+ALT_DAYS_LIMIT_PLEDGE_JOIN = TimeUnit.DAYS
 					.toMillis(Integer.parseInt(altSettings.getProperty("DaysLimitPledgeJoin", "0")));
 
 			ALT_JPPRIVILEGED = Boolean.parseBoolean(altSettings.getProperty("JpPrivileged", "False"));
@@ -1139,12 +1145,16 @@ public final class Config {
 			ALT_GMSHOP_MAX_ID = Integer.parseInt(pValue);
 		} else if (pName.equalsIgnoreCase("HalloweenEvent")) {
 			ALT_HALLOWEENEVENT = Boolean.valueOf(pValue);
-		} else if (pName.equalsIgnoreCase("HalloweenEventNpc")) {
-			ALT_HALLOWEENEVENTNPC = Boolean.valueOf(pValue);
-		} else if (pName.equalsIgnoreCase("PolyEvent")) {
-			ALT_POLYEVENT = Boolean.valueOf(pValue);
-		} else if (pName.equalsIgnoreCase("JpPrivileged")) {
-			ALT_JPPRIVILEGED = Boolean.valueOf(pValue);
+                } else if (pName.equalsIgnoreCase("HalloweenEventNpc")) {
+                        ALT_HALLOWEENEVENTNPC = Boolean.valueOf(pValue);
+                } else if (pName.equalsIgnoreCase("PolyEvent")) {
+                        ALT_POLYEVENT = Boolean.valueOf(pValue);
+                } else if (pName.equalsIgnoreCase("TargetLockAssistEnabled")) {
+                        ENABLE_TARGET_LOCK_ASSIST = Boolean.parseBoolean(pValue);
+                } else if (pName.equalsIgnoreCase("TargetLockAssistInterval")) {
+                        TARGET_LOCK_ASSIST_INTERVAL = Integer.parseInt(pValue);
+                } else if (pName.equalsIgnoreCase("JpPrivileged")) {
+                        ALT_JPPRIVILEGED = Boolean.valueOf(pValue);
 		} else if (pName.equalsIgnoreCase("TalkingScrollQuest")) {
 			ALT_TALKINGSCROLLQUEST = Boolean.valueOf(pValue);
 		} else if (pName.equalsIgnoreCase("HouseTaxInterval")) {

--- a/src/l1j/server/server/clientpackets/C_TargetLock.java
+++ b/src/l1j/server/server/clientpackets/C_TargetLock.java
@@ -1,0 +1,54 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ *
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+package l1j.server.server.clientpackets;
+
+import l1j.server.Config;
+import l1j.server.server.controllers.TargetLockController;
+import l1j.server.server.model.Instance.L1PcInstance;
+import l1j.server.server.network.Client;
+
+public class C_TargetLock extends ClientBasePacket {
+
+	private static final String C_TARGET_LOCK = "[C] C_TargetLock";
+
+	public C_TargetLock(byte[] decrypt, Client client) {
+		super(decrypt);
+
+		if (!Config.ENABLE_TARGET_LOCK_ASSIST) {
+			return;
+		}
+
+		L1PcInstance pc = client.getActiveChar();
+		if (pc == null) {
+			return;
+		}
+
+		int targetId = 0;
+		if (decrypt.length >= 5) {
+			targetId = readD();
+		}
+
+		TargetLockController.getInstance().handleLockRequest(pc, targetId);
+	}
+
+	@Override
+	public String getType() {
+		return C_TARGET_LOCK;
+	}
+}

--- a/src/l1j/server/server/clientpackets/C_TargetLockAttack.java
+++ b/src/l1j/server/server/clientpackets/C_TargetLockAttack.java
@@ -1,0 +1,61 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ *
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+package l1j.server.server.clientpackets;
+
+import l1j.server.Config;
+import l1j.server.server.controllers.TargetLockController;
+import l1j.server.server.model.Instance.L1PcInstance;
+import l1j.server.server.network.Client;
+
+public class C_TargetLockAttack extends ClientBasePacket {
+
+	private static final String C_TARGET_LOCK_ATTACK = "[C] C_TargetLockAttack";
+
+	public C_TargetLockAttack(byte[] decrypt, Client client) {
+		super(decrypt);
+
+		if (!Config.ENABLE_TARGET_LOCK_ASSIST) {
+			return;
+		}
+
+		L1PcInstance pc = client.getActiveChar();
+		if (pc == null) {
+			return;
+		}
+
+		int targetId = 0;
+		int clickX = pc.getX();
+		int clickY = pc.getY();
+
+		if (decrypt.length >= 5) {
+			targetId = readD();
+		}
+		if (decrypt.length >= 9) {
+			clickX = readH();
+			clickY = readH();
+		}
+
+		TargetLockController.getInstance().handleAttackRequest(pc, targetId, clickX, clickY);
+	}
+
+	@Override
+	public String getType() {
+		return C_TARGET_LOCK_ATTACK;
+	}
+}

--- a/src/l1j/server/server/controllers/TargetLockController.java
+++ b/src/l1j/server/server/controllers/TargetLockController.java
@@ -1,0 +1,114 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ *
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+package l1j.server.server.controllers;
+
+import java.util.ArrayList;
+
+import l1j.server.Config;
+import l1j.server.server.model.L1Character;
+import l1j.server.server.model.L1Object;
+import l1j.server.server.model.L1World;
+import l1j.server.server.model.Instance.L1MonsterInstance;
+import l1j.server.server.model.Instance.L1PcInstance;
+import l1j.server.server.serverpackets.S_SystemMessage;
+
+public class TargetLockController {
+
+	private static final TargetLockController INSTANCE = new TargetLockController();
+
+	private TargetLockController() {
+	}
+
+	public static TargetLockController getInstance() {
+		return INSTANCE;
+	}
+
+	public void handleLockRequest(L1PcInstance pc, int requestedTargetId) {
+		if (pc == null || !Config.ENABLE_TARGET_LOCK_ASSIST) {
+			return;
+		}
+
+		L1Character target = resolveTarget(pc, requestedTargetId, true);
+		if (target != null) {
+			pc.setTargetLock(target);
+			pc.sendPackets(new S_SystemMessage(String.format("Target locked: %s", target.getName())));
+		} else {
+			pc.clearTargetLock();
+			pc.sendPackets(new S_SystemMessage("Target lock cleared."));
+		}
+	}
+
+	public void handleAttackRequest(L1PcInstance pc, int requestedTargetId, int clickX, int clickY) {
+		if (pc == null || !Config.ENABLE_TARGET_LOCK_ASSIST) {
+			return;
+		}
+
+		L1Character target = pc.getTargetLockTarget();
+		if (target == null || (requestedTargetId > 0 && target.getId() != requestedTargetId)) {
+			target = resolveTarget(pc, requestedTargetId, true);
+		}
+		if (target == null) {
+			pc.sendPackets(new S_SystemMessage("There is no valid monster to attack."));
+			return;
+		}
+
+		pc.setTargetLock(target);
+		pc.startTargetLockAssist();
+	}
+
+	private L1Character resolveTarget(L1PcInstance pc, int requestedTargetId, boolean allowNearest) {
+		L1Character target = null;
+		if (requestedTargetId > 0) {
+			L1Object obj = L1World.getInstance().findObject(requestedTargetId);
+			if (obj instanceof L1MonsterInstance) {
+				L1MonsterInstance monster = (L1MonsterInstance) obj;
+				if (!monster.isDead() && monster.getMapId() == pc.getMapId()) {
+					target = monster;
+				}
+			}
+		}
+
+		if (target == null && allowNearest) {
+			target = findNearestMonster(pc);
+		}
+
+		return target;
+	}
+
+	private L1MonsterInstance findNearestMonster(L1PcInstance pc) {
+		ArrayList<L1Object> objects = L1World.getInstance().getVisibleObjects(pc);
+		L1MonsterInstance closest = null;
+		double bestDistance = Double.MAX_VALUE;
+		for (L1Object obj : objects) {
+			if (!(obj instanceof L1MonsterInstance)) {
+				continue;
+			}
+			L1MonsterInstance monster = (L1MonsterInstance) obj;
+			if (monster.isDead() || monster.getMapId() != pc.getMapId()) {
+				continue;
+			}
+			double distance = pc.getLocation().getLineDistance(monster.getLocation());
+			if (distance < bestDistance) {
+				bestDistance = distance;
+				closest = monster;
+			}
+		}
+		return closest;
+	}
+}

--- a/src/l1j/server/server/encryptions/Opcodes.java
+++ b/src/l1j/server/server/encryptions/Opcodes.java
@@ -94,8 +94,10 @@ public class Opcodes {
 	public static final int C_OPCODE_RESULT = 40;
 	public static final int C_OPCODE_RETURNTOLOGIN = 218;
 	public static final int C_OPCODE_SELECTLIST = 238;
-	public static final int C_OPCODE_SELECTTARGET = 155;
-	public static final int C_OPCODE_SENDLOCATION = 41;
+public static final int C_OPCODE_SELECTTARGET = 155;
+public static final int C_OPCODE_TARGETLOCK = 248;
+public static final int C_OPCODE_TARGETLOCKATTACK = 252;
+public static final int C_OPCODE_SENDLOCATION = 41;
 	public static final int C_OPCODE_SHIP = 117;
 	public static final int C_OPCODE_SHOP = 16;
 	public static final int C_OPCODE_SKILLBUY = 173;

--- a/src/l1j/server/server/model/monitor/L1TargetLockMonitor.java
+++ b/src/l1j/server/server/model/monitor/L1TargetLockMonitor.java
@@ -1,0 +1,33 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ *
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+package l1j.server.server.model.monitor;
+
+import l1j.server.server.model.Instance.L1PcInstance;
+
+public class L1TargetLockMonitor extends L1PcMonitor {
+
+	public L1TargetLockMonitor(int oId) {
+		super(oId);
+	}
+
+	@Override
+	public void execTask(L1PcInstance pc) {
+		pc.onTargetLockMonitorTick();
+	}
+}

--- a/src/l1j/server/server/network/PacketHandler.java
+++ b/src/l1j/server/server/network/PacketHandler.java
@@ -90,6 +90,8 @@ import static l1j.server.server.encryptions.Opcodes.C_OPCODE_RESULT;
 import static l1j.server.server.encryptions.Opcodes.C_OPCODE_RETURNTOLOGIN;
 import static l1j.server.server.encryptions.Opcodes.C_OPCODE_SELECTLIST;
 import static l1j.server.server.encryptions.Opcodes.C_OPCODE_SELECTTARGET;
+import static l1j.server.server.encryptions.Opcodes.C_OPCODE_TARGETLOCK;
+import static l1j.server.server.encryptions.Opcodes.C_OPCODE_TARGETLOCKATTACK;
 import static l1j.server.server.encryptions.Opcodes.C_OPCODE_SENDLOCATION;
 import static l1j.server.server.encryptions.Opcodes.C_OPCODE_SHIP;
 import static l1j.server.server.encryptions.Opcodes.C_OPCODE_SHOP;
@@ -181,6 +183,8 @@ import l1j.server.server.clientpackets.C_Result;
 import l1j.server.server.clientpackets.C_ReturnToLogin;
 import l1j.server.server.clientpackets.C_SelectList;
 import l1j.server.server.clientpackets.C_SelectTarget;
+import l1j.server.server.clientpackets.C_TargetLock;
+import l1j.server.server.clientpackets.C_TargetLockAttack;
 import l1j.server.server.clientpackets.C_SendLocation;
 import l1j.server.server.clientpackets.C_ServerVersion;
 import l1j.server.server.clientpackets.C_Ship;
@@ -470,13 +474,19 @@ public class PacketHandler {
 		case C_OPCODE_HIRESOLDIER:
 			new C_HireSoldier(abyte0, _client);
 			break;
-		case C_OPCODE_FISHCLICK:
-			new C_FishClick(abyte0, _client);
-			break;
-		case C_OPCODE_SELECTTARGET:
-			new C_SelectTarget(abyte0, _client);
-			break;
-		case C_OPCODE_PETMENU:
+                case C_OPCODE_FISHCLICK:
+                        new C_FishClick(abyte0, _client);
+                        break;
+                case C_OPCODE_SELECTTARGET:
+                        new C_SelectTarget(abyte0, _client);
+                        break;
+                case C_OPCODE_TARGETLOCK:
+                        new C_TargetLock(abyte0, _client);
+                        break;
+                case C_OPCODE_TARGETLOCKATTACK:
+                        new C_TargetLockAttack(abyte0, _client);
+                        break;
+                case C_OPCODE_PETMENU:
 			new C_PetMenu(abyte0, _client);
 			break;
 		case C_OPCODE_USEPETITEM:


### PR DESCRIPTION
## Summary
- add configuration toggles for the target lock melee assist system
- handle new target lock packets and maintain the locked target and auto-attack loop on the server
- implement a monitor-driven chase and melee routine for locked targets on player instances

## Testing
- ant compile *(fails: `ant` not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e175787628833293d4166224b53ad1