### PR TITLE
Fix missing skill imports in L1PcInstance

### DIFF
--- a/src/l1j/server/server/model/Instance/L1PcInstance.java
+++ b/src/l1j/server/server/model/Instance/L1PcInstance.java
@@ -1,5 +1,6 @@
 package l1j.server.server.model.Instance;
 
+import static l1j.server.server.model.skill.L1SkillId.ABSOLUTE_BARRIER;
 import static l1j.server.server.model.skill.L1SkillId.BLIND_HIDING;
 import static l1j.server.server.model.skill.L1SkillId.BLOODLUST;
 import static l1j.server.server.model.skill.L1SkillId.CANCELLATION;
@@ -17,6 +18,7 @@ import static l1j.server.server.model.skill.L1SkillId.HOLY_WALK;
 import static l1j.server.server.model.skill.L1SkillId.ILLUSION_AVATAR;
 import static l1j.server.server.model.skill.L1SkillId.INVISIBILITY;
 import static l1j.server.server.model.skill.L1SkillId.MASS_SLOW;
+import static l1j.server.server.model.skill.L1SkillId.MEDITATION;
 import static l1j.server.server.model.skill.L1SkillId.MORTAL_BODY;
 import static l1j.server.server.model.skill.L1SkillId.MOVING_ACCELERATION;
 import static l1j.server.server.model.skill.L1SkillId.SHAPE_CHANGE;


### PR DESCRIPTION
## Summary
- add the missing static imports for ABSOLUTE_BARRIER and MEDITATION in L1PcInstance to resolve compile failures

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e180549b688332a73e4911b271a56f