### PR TITLE
Add visual indicators to target lock assist

### DIFF
--- a/src/l1j/server/server/controllers/TargetLockController.java
+++ b/src/l1j/server/server/controllers/TargetLockController.java
@@ -44,14 +44,15 @@ public class TargetLockController {
 			return;
 		}
 
-		L1Character target = resolveTarget(pc, requestedTargetId, true);
-		if (target != null) {
-			pc.setTargetLock(target);
-			pc.sendPackets(new S_SystemMessage(String.format("Target locked: %s", target.getName())));
-		} else {
-			pc.clearTargetLock();
-			pc.sendPackets(new S_SystemMessage("Target lock cleared."));
-		}
+                L1Character target = resolveTarget(pc, requestedTargetId, true);
+                if (target != null) {
+                        pc.setTargetLock(target);
+                        pc.showTargetLockSelectionIndicator(target);
+                        pc.sendPackets(new S_SystemMessage(String.format("Target locked: %s", target.getName())));
+                } else {
+                        pc.clearTargetLock();
+                        pc.sendPackets(new S_SystemMessage("Target lock cleared."));
+                }
 	}
 
 	public void handleAttackRequest(L1PcInstance pc, int requestedTargetId, int clickX, int clickY) {
@@ -63,14 +64,15 @@ public class TargetLockController {
 		if (target == null || (requestedTargetId > 0 && target.getId() != requestedTargetId)) {
 			target = resolveTarget(pc, requestedTargetId, true);
 		}
-		if (target == null) {
-			pc.sendPackets(new S_SystemMessage("There is no valid monster to attack."));
-			return;
-		}
+                if (target == null) {
+                        pc.sendPackets(new S_SystemMessage("There is no valid monster to attack."));
+                        return;
+                }
 
-		pc.setTargetLock(target);
-		pc.startTargetLockAssist();
-	}
+                pc.setTargetLock(target);
+                pc.showTargetLockSelectionIndicator(target);
+                pc.startTargetLockAssist();
+        }
 
 	private L1Character resolveTarget(L1PcInstance pc, int requestedTargetId, boolean allowNearest) {
 		L1Character target = null;


### PR DESCRIPTION
## Summary
- highlight locked monsters with a teal effect and clear the previous indicator when target lock changes
- recolor the indicator to purple while target lock assist attacks and revert/clean it up on stop, death, or logout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1891078c88332819ccb01100f2ca7