### PR TITLE
Improve target lock visuals and defaults

### DIFF
--- a/config/altsettings.properties
+++ b/config/altsettings.properties
@@ -81,7 +81,7 @@ BossEventDailyReset = True
 
 # Enables the server-wide target lock melee assist system. When enabled, players can
 # lock on to monsters and automatically chase them for melee attacks.
-TargetLockAssistEnabled = False
+TargetLockAssistEnabled = True
 
 # Update frequency for the target lock melee assist monitor in milliseconds.
 TargetLockAssistInterval = 200

--- a/src/l1j/server/Config.java
+++ b/src/l1j/server/Config.java
@@ -820,7 +820,7 @@ public static boolean RESTRICT_ACCOUNT_IPS;
 			ENABLE_AUTO_QUEST_LEVEL15 = Boolean.parseBoolean(altSettings.getProperty("EnableAutoQuestLevel15", "True"));
                         ENABLE_AUTO_QUEST_LEVEL30 = Boolean.parseBoolean(altSettings.getProperty("EnableAutoQuestLevel30", "True"));
                         ENABLE_AUTO_QUEST_LEVEL50 = Boolean.parseBoolean(altSettings.getProperty("EnableAutoQuestLevel50", "True"));
-                        ENABLE_TARGET_LOCK_ASSIST = Boolean.parseBoolean(altSettings.getProperty("TargetLockAssistEnabled", "False"));
+                        ENABLE_TARGET_LOCK_ASSIST = Boolean.parseBoolean(altSettings.getProperty("TargetLockAssistEnabled", "True"));
                         TARGET_LOCK_ASSIST_INTERVAL = Integer.parseInt(altSettings.getProperty("TargetLockAssistInterval", "200"));
 
 

--- a/src/l1j/server/server/controllers/TargetLockController.java
+++ b/src/l1j/server/server/controllers/TargetLockController.java
@@ -44,14 +44,15 @@ public class TargetLockController {
 			return;
 		}
 
-		L1Character target = resolveTarget(pc, requestedTargetId, true);
-		if (target != null) {
-			pc.setTargetLock(target);
-			pc.sendPackets(new S_SystemMessage(String.format("Target locked: %s", target.getName())));
-		} else {
-			pc.clearTargetLock();
-			pc.sendPackets(new S_SystemMessage("Target lock cleared."));
-		}
+                L1Character target = resolveTarget(pc, requestedTargetId, true);
+                if (target != null) {
+                        pc.setTargetLock(target);
+                        pc.showTargetLockSelectionIndicator(target);
+                        pc.sendPackets(new S_SystemMessage(String.format("Target locked: %s", target.getName())));
+                } else {
+                        pc.clearTargetLock();
+                        pc.sendPackets(new S_SystemMessage("Target lock cleared."));
+                }
 	}
 
 	public void handleAttackRequest(L1PcInstance pc, int requestedTargetId, int clickX, int clickY) {
@@ -63,14 +64,15 @@ public class TargetLockController {
 		if (target == null || (requestedTargetId > 0 && target.getId() != requestedTargetId)) {
 			target = resolveTarget(pc, requestedTargetId, true);
 		}
-		if (target == null) {
-			pc.sendPackets(new S_SystemMessage("There is no valid monster to attack."));
-			return;
-		}
+                if (target == null) {
+                        pc.sendPackets(new S_SystemMessage("There is no valid monster to attack."));
+                        return;
+                }
 
-		pc.setTargetLock(target);
-		pc.startTargetLockAssist();
-	}
+                pc.setTargetLock(target);
+                pc.showTargetLockSelectionIndicator(target);
+                pc.startTargetLockAssist();
+        }
 
 	private L1Character resolveTarget(L1PcInstance pc, int requestedTargetId, boolean allowNearest) {
 		L1Character target = null;

--- a/src/l1j/server/server/controllers/TargetLockController.java
+++ b/src/l1j/server/server/controllers/TargetLockController.java
@@ -55,12 +55,12 @@ public class TargetLockController {
                 pc.clearTargetLock();
         }
 
-	public void handleAttackRequest(L1PcInstance pc, int requestedTargetId, int clickX, int clickY) {
-		if (pc == null || !Config.ENABLE_TARGET_LOCK_ASSIST) {
-			return;
-		}
+        public void handleAttackRequest(L1PcInstance pc, int requestedTargetId, int clickX, int clickY) {
+                if (pc == null || !Config.ENABLE_TARGET_LOCK_ASSIST) {
+                        return;
+                }
 
-		L1Character target = pc.getTargetLockTarget();
+                L1Character target = pc.getTargetLockTarget();
                 if (target == null || (requestedTargetId > 0 && target.getId() != requestedTargetId)) {
                         boolean allowNearest = requestedTargetId <= 0;
                         target = resolveTarget(pc, requestedTargetId, allowNearest);

--- a/src/l1j/server/server/controllers/TargetLockController.java
+++ b/src/l1j/server/server/controllers/TargetLockController.java
@@ -39,41 +39,43 @@ public class TargetLockController {
 		return INSTANCE;
 	}
 
-        public void handleLockRequest(L1PcInstance pc, int requestedTargetId) {
-                if (pc == null || !Config.ENABLE_TARGET_LOCK_ASSIST) {
-                        return;
-                }
+	public void handleLockRequest(L1PcInstance pc, int requestedTargetId) {
+		if (pc == null || !Config.ENABLE_TARGET_LOCK_ASSIST) {
+			return;
+		}
 
-                boolean allowNearest = requestedTargetId <= 0 && !pc.hasTargetLock();
-                L1Character target = resolveTarget(pc, requestedTargetId, allowNearest);
-                if (target != null) {
-                        pc.setTargetLock(target);
-                        pc.showTargetLockSelectionIndicator(target);
-                        return;
-                }
+		boolean allowNearest = requestedTargetId <= 0 && !pc.hasTargetLock();
+		L1Character target = resolveTarget(pc, requestedTargetId, allowNearest);
+		if (target != null) {
+			pc.setTargetLock(target);
+			pc.showTargetLockSelectionIndicator(target);
+			pc.sendPackets(new S_SystemMessage(String.format("Target locked: %s", target.getName())));
+			return;
+		}
 
-                pc.clearTargetLock();
-        }
+		pc.clearTargetLock();
+		pc.sendPackets(new S_SystemMessage("Target lock cleared."));
+	}
 
-        public void handleAttackRequest(L1PcInstance pc, int requestedTargetId, int clickX, int clickY) {
-                if (pc == null || !Config.ENABLE_TARGET_LOCK_ASSIST) {
-                        return;
-                }
+	public void handleAttackRequest(L1PcInstance pc, int requestedTargetId, int clickX, int clickY) {
+		if (pc == null || !Config.ENABLE_TARGET_LOCK_ASSIST) {
+			return;
+		}
 
-                L1Character target = pc.getTargetLockTarget();
-                if (target == null || (requestedTargetId > 0 && target.getId() != requestedTargetId)) {
-                        boolean allowNearest = requestedTargetId <= 0;
-                        target = resolveTarget(pc, requestedTargetId, allowNearest);
-                }
-                if (target == null) {
-                        pc.sendPackets(new S_SystemMessage("There is no valid monster to attack."));
-                        return;
-                }
+		L1Character target = pc.getTargetLockTarget();
+		if (target == null || (requestedTargetId > 0 && target.getId() != requestedTargetId)) {
+			boolean allowNearest = requestedTargetId <= 0;
+			target = resolveTarget(pc, requestedTargetId, allowNearest);
+		}
+		if (target == null) {
+			pc.sendPackets(new S_SystemMessage("There is no valid monster to attack."));
+			return;
+		}
 
-                pc.setTargetLock(target);
-                pc.showTargetLockSelectionIndicator(target);
-                pc.startTargetLockAssist();
-        }
+		pc.setTargetLock(target);
+		pc.showTargetLockSelectionIndicator(target);
+		pc.startTargetLockAssist();
+	}
 
 	private L1Character resolveTarget(L1PcInstance pc, int requestedTargetId, boolean allowNearest) {
 		L1Character target = null;

--- a/src/l1j/server/server/controllers/TargetLockController.java
+++ b/src/l1j/server/server/controllers/TargetLockController.java
@@ -39,19 +39,21 @@ public class TargetLockController {
 		return INSTANCE;
 	}
 
-	public void handleLockRequest(L1PcInstance pc, int requestedTargetId) {
-		if (pc == null || !Config.ENABLE_TARGET_LOCK_ASSIST) {
-			return;
-		}
+        public void handleLockRequest(L1PcInstance pc, int requestedTargetId) {
+                if (pc == null || !Config.ENABLE_TARGET_LOCK_ASSIST) {
+                        return;
+                }
 
-                L1Character target = resolveTarget(pc, requestedTargetId, true);
+                boolean allowNearest = requestedTargetId <= 0 && !pc.hasTargetLock();
+                L1Character target = resolveTarget(pc, requestedTargetId, allowNearest);
                 if (target != null) {
                         pc.setTargetLock(target);
                         pc.showTargetLockSelectionIndicator(target);
-                } else {
-                        pc.clearTargetLock();
+                        return;
                 }
-	}
+
+                pc.clearTargetLock();
+        }
 
 	public void handleAttackRequest(L1PcInstance pc, int requestedTargetId, int clickX, int clickY) {
 		if (pc == null || !Config.ENABLE_TARGET_LOCK_ASSIST) {
@@ -59,9 +61,10 @@ public class TargetLockController {
 		}
 
 		L1Character target = pc.getTargetLockTarget();
-		if (target == null || (requestedTargetId > 0 && target.getId() != requestedTargetId)) {
-			target = resolveTarget(pc, requestedTargetId, true);
-		}
+                if (target == null || (requestedTargetId > 0 && target.getId() != requestedTargetId)) {
+                        boolean allowNearest = requestedTargetId <= 0;
+                        target = resolveTarget(pc, requestedTargetId, allowNearest);
+                }
                 if (target == null) {
                         pc.sendPackets(new S_SystemMessage("There is no valid monster to attack."));
                         return;

--- a/src/l1j/server/server/controllers/TargetLockController.java
+++ b/src/l1j/server/server/controllers/TargetLockController.java
@@ -48,10 +48,8 @@ public class TargetLockController {
                 if (target != null) {
                         pc.setTargetLock(target);
                         pc.showTargetLockSelectionIndicator(target);
-                        pc.sendPackets(new S_SystemMessage(String.format("Target locked: %s", target.getName())));
                 } else {
                         pc.clearTargetLock();
-                        pc.sendPackets(new S_SystemMessage("Target lock cleared."));
                 }
 	}
 

--- a/src/l1j/server/server/model/Instance/L1PcInstance.java
+++ b/src/l1j/server/server/model/Instance/L1PcInstance.java
@@ -254,9 +254,8 @@ private ScheduledFuture<?> _teleDelayFuture;
 				Thread.currentThread().setName("L1PcInstance-Death");
 				L1Character lastAttacker = _lastAttacker;
 				_lastAttacker = null;
-                                setCurrentHp(0);
-                                setGresValid(false);
-                                clearTargetLock();
+				setCurrentHp(0);
+				setGresValid(false);
 
 				if (isTeleport()) {
 					GeneralThreadPool.getInstance().schedule(this, 300);
@@ -565,17 +564,11 @@ private ScheduledFuture<?> _autoUpdateFuture;
 private ScheduledFuture<?> _targetLockFuture;
 
 private volatile int _targetLockId;
-
 private volatile boolean _targetLockAssistActive;
-
 private volatile int _targetLockIndicatorTargetId;
-
 private int _targetLockIndicatorX;
-
 private int _targetLockIndicatorY;
-
 private short _targetLockIndicatorMapId;
-
 private TargetLockIndicatorColor _targetLockIndicatorColor = TargetLockIndicatorColor.NONE;
 private long _targetLockIndicatorLastBroadcastMillis;
 
@@ -3232,12 +3225,11 @@ private enum TargetLockIndicatorColor {
 		return L1ClassId.isMage(getClassId());
 	}
 
-
-	public void logout() {
-		L1World world = L1World.getInstance();
-		clearTargetLock();
-		if (getClanid() != 0) {
-			L1Clan clan = world.getClan(getClanname());
+public void logout() {
+L1World world = L1World.getInstance();
+clearTargetLock();
+if (getClanid() != 0) {
+L1Clan clan = world.getClan(getClanname());
 			if (clan != null) {
 				if (clan.getWarehouseUsingChar() == getId()) {
 					clan.setWarehouseUsingChar(0);
@@ -4549,19 +4541,19 @@ private enum TargetLockIndicatorColor {
 				INTERVAL_AUTO_UPDATE);
 	}
 
-        public void stopEtcMonitor() {
-                if (_autoUpdateFuture != null) {
-                        _autoUpdateFuture.cancel(true);
-                        _autoUpdateFuture = null;
-                }
-                if (_expMonitorFuture != null) {
-                        _expMonitorFuture.cancel(true);
-                        _expMonitorFuture = null;
-                }
-                if (_ghostFuture != null) {
-                        _ghostFuture.cancel(true);
-                        _ghostFuture = null;
-                }
+public void stopEtcMonitor() {
+if (_autoUpdateFuture != null) {
+_autoUpdateFuture.cancel(true);
+_autoUpdateFuture = null;
+}
+if (_expMonitorFuture != null) {
+_expMonitorFuture.cancel(true);
+_expMonitorFuture = null;
+}
+if (_ghostFuture != null) {
+_ghostFuture.cancel(true);
+_ghostFuture = null;
+}
                 if (_hellFuture != null) {
                         _hellFuture.cancel(true);
                         _hellFuture = null;
@@ -4624,17 +4616,17 @@ private enum TargetLockIndicatorColor {
         }
 
         public L1Character getTargetLockTarget() {
-                int targetId = _targetLockId;
-                if (targetId == 0) {
-                        return null;
-                }
-                L1Object obj = L1World.getInstance().findObject(targetId);
-                if (!(obj instanceof L1Character)) {
-                        clearTargetLock();
-                        return null;
-                }
-                return (L1Character) obj;
-        }
+int targetId = _targetLockId;
+if (targetId == 0) {
+return null;
+}
+L1Object obj = L1World.getInstance().findObject(targetId);
+if (!(obj instanceof L1Character)) {
+clearTargetLock();
+return null;
+}
+return (L1Character) obj;
+}
 
         public synchronized void startTargetLockAssist() {
                 if (!Config.ENABLE_TARGET_LOCK_ASSIST) {
@@ -4659,26 +4651,26 @@ private enum TargetLockIndicatorColor {
                 }
         }
 
-	public void showTargetLockSelectionIndicator(L1Character target) {
-		updateTargetLockIndicator(target, TargetLockIndicatorColor.TEAL);
-	}
+        public void showTargetLockSelectionIndicator(L1Character target) {
+                updateTargetLockIndicator(target, TargetLockIndicatorColor.TEAL);
+        }
 
-	public void showTargetLockAssistIndicator(L1Character target) {
-		updateTargetLockIndicator(target, TargetLockIndicatorColor.PURPLE);
-	}
+        public void showTargetLockAssistIndicator(L1Character target) {
+                updateTargetLockIndicator(target, TargetLockIndicatorColor.PURPLE);
+        }
 
-	private void revertTargetLockIndicatorToIdle() {
-		if (!Config.ENABLE_TARGET_LOCK_ASSIST) {
-			clearTargetLockIndicator();
-			return;
-		}
-		L1Character target = getTargetLockTarget();
-		if (target == null) {
-			clearTargetLockIndicator();
-			return;
-		}
-		updateTargetLockIndicator(target, TargetLockIndicatorColor.TEAL);
-	}
+        private void revertTargetLockIndicatorToIdle() {
+                if (!Config.ENABLE_TARGET_LOCK_ASSIST) {
+                        clearTargetLockIndicator();
+                        return;
+                }
+                L1Character target = getTargetLockTarget();
+                if (target == null) {
+                        clearTargetLockIndicator();
+                        return;
+                }
+                updateTargetLockIndicator(target, TargetLockIndicatorColor.TEAL);
+        }
 
         private synchronized void updateTargetLockIndicator(L1Character target, TargetLockIndicatorColor color) {
                 if (!Config.ENABLE_TARGET_LOCK_ASSIST) {
@@ -4761,13 +4753,11 @@ private enum TargetLockIndicatorColor {
                         clearTargetLock();
                         return;
                 }
-
                 L1Character target = getTargetLockTarget();
                 if (target == null) {
                         clearTargetLock();
                         return;
                 }
-
                 TargetLockIndicatorColor indicatorColor = _targetLockAssistActive ? TargetLockIndicatorColor.PURPLE
                                 : TargetLockIndicatorColor.TEAL;
                 updateTargetLockIndicator(target, indicatorColor);
@@ -4776,12 +4766,10 @@ private enum TargetLockIndicatorColor {
                         stopTargetLockAssist();
                         return;
                 }
-
                 if (target.isDead() || target.getMapId() != getMapId()) {
                         clearTargetLock();
                         return;
                 }
-
                 double distance = getLocation().getLineDistance(target.getLocation());
                 if (distance > 20D) {
                         clearTargetLock();
@@ -4797,7 +4785,6 @@ private enum TargetLockIndicatorColor {
                         stopTargetLockAssist();
                         return;
                 }
-
                 int range = getTargetLockRange();
                 if (!isAttackPosition(target.getX(), target.getY(), range)) {
                         updateTargetLockIndicator(target, TargetLockIndicatorColor.TEAL);
@@ -4806,7 +4793,6 @@ private enum TargetLockIndicatorColor {
                         }
                         return;
                 }
-
                 if (Config.CHECK_ATTACK_INTERVAL) {
                         int result = getAcceleratorChecker().checkInterval(AcceleratorChecker.ACT_TYPE.ATTACK);
                         if (result == AcceleratorChecker.R_LIMITEXCEEDED) {
@@ -4814,7 +4800,6 @@ private enum TargetLockIndicatorColor {
                                 return;
                         }
                 }
-
                 if (hasSkillEffect(ABSOLUTE_BARRIER)) {
                         killSkillEffectTimer(ABSOLUTE_BARRIER);
                         startHpRegeneration();
@@ -4829,39 +4814,39 @@ private enum TargetLockIndicatorColor {
                 target.onAction(this);
         }
 
-        private int getTargetLockRange() {
-                L1ItemInstance weapon = getWeapon();
-                if (weapon != null && weapon.getItem() != null) {
-                        int range = weapon.getItem().getRange();
-                        if (range > 0) {
-                                return range;
-                        }
-                }
-                return 1;
-        }
+private int getTargetLockRange() {
+L1ItemInstance weapon = getWeapon();
+if (weapon != null && weapon.getItem() != null) {
+int range = weapon.getItem().getRange();
+if (range > 0) {
+return range;
+}
+}
+return 1;
+}
 
-        private boolean moveTowardsTarget(L1Character target) {
-                int dir = targetDirection(target.getX(), target.getY());
-                int newX = getX() + TARGET_LOCK_MOVE_X[dir];
-                int newY = getY() + TARGET_LOCK_MOVE_Y[dir];
-                L1Map map = getMap();
-                if (map == null) {
-                        return false;
-                }
-                map.setPassable(getLocation(), true);
-                if (!map.isPassable(newX, newY)) {
-                        map.setPassable(getLocation(), false);
-                        return false;
-                }
-                setHeading(dir);
-                getLocation().set(newX, newY);
-                setRegenState(REGENSTATE_MOVE);
-                S_MoveCharPacket movePacket = new S_MoveCharPacket(this);
-                sendPackets(movePacket);
-                broadcastPacket(movePacket);
-                map.setPassable(getLocation(), false);
-                return true;
-        }
+private boolean moveTowardsTarget(L1Character target) {
+int dir = targetDirection(target.getX(), target.getY());
+int newX = getX() + TARGET_LOCK_MOVE_X[dir];
+int newY = getY() + TARGET_LOCK_MOVE_Y[dir];
+L1Map map = getMap();
+if (map == null) {
+return false;
+}
+map.setPassable(getLocation(), true);
+if (!map.isPassable(newX, newY)) {
+map.setPassable(getLocation(), false);
+return false;
+}
+setHeading(dir);
+getLocation().set(newX, newY);
+setRegenState(REGENSTATE_MOVE);
+S_MoveCharPacket movePacket = new S_MoveCharPacket(this);
+sendPackets(movePacket);
+broadcastPacket(movePacket);
+map.setPassable(getLocation(), false);
+return true;
+}
 
 	public void stopHpRegeneration() {
 		if (_hpRegenActive) {

--- a/src/l1j/server/server/model/Instance/L1PcInstance.java
+++ b/src/l1j/server/server/model/Instance/L1PcInstance.java
@@ -127,6 +127,7 @@ import l1j.server.server.model.skill.L1SkillId;
 import l1j.server.server.model.skill.L1SkillUse;
 import l1j.server.server.network.Client;
 import l1j.server.server.network.DelayedPacket;
+import l1j.server.server.serverpackets.S_EffectLocation;
 import l1j.server.server.serverpackets.S_MoveCharPacket;
 import l1j.server.server.serverpackets.S_BlueMessage;
 import l1j.server.server.serverpackets.S_CastleMaster;
@@ -134,7 +135,6 @@ import l1j.server.server.serverpackets.S_ChangeShape;
 import l1j.server.server.serverpackets.S_Disconnect;
 import l1j.server.server.serverpackets.S_DoActionGFX;
 import l1j.server.server.serverpackets.S_DoActionShop;
-import l1j.server.server.serverpackets.S_EffectLocation;
 import l1j.server.server.serverpackets.S_EquipmentWindow;
 import l1j.server.server.serverpackets.S_Exp;
 import l1j.server.server.serverpackets.S_HPMeter;
@@ -262,8 +262,9 @@ private ScheduledFuture<?> _teleDelayFuture;
 					return;
 				}
 
-				stopHpRegeneration();
-				stopMpRegeneration();
+                                clearTargetLock();
+                                stopHpRegeneration();
+                                stopMpRegeneration();
 
 				int targetobjid = getId();
 				getMap().setPassable(getLocation(), true);
@@ -4535,320 +4536,13 @@ L1Clan clan = world.getClan(getClanname());
 		}
 	}
 
-	public void startObjectAutoUpdate() {
-		removeAllKnownObjects();
-		_autoUpdateFuture = GeneralThreadPool.getInstance().pcScheduleAtFixedRate(new L1PcAutoUpdate(getId()), 0L,
-				INTERVAL_AUTO_UPDATE);
-	}
-
-public void stopEtcMonitor() {
-if (_autoUpdateFuture != null) {
-_autoUpdateFuture.cancel(true);
-_autoUpdateFuture = null;
-}
-if (_expMonitorFuture != null) {
-_expMonitorFuture.cancel(true);
-_expMonitorFuture = null;
-}
-if (_ghostFuture != null) {
-_ghostFuture.cancel(true);
-_ghostFuture = null;
-}
-                if (_hellFuture != null) {
-                        _hellFuture.cancel(true);
-                        _hellFuture = null;
-                }
-                clearTargetLock();
+        public void startObjectAutoUpdate() {
+                removeAllKnownObjects();
+                _autoUpdateFuture = GeneralThreadPool.getInstance().pcScheduleAtFixedRate(new L1PcAutoUpdate(getId()), 0L,
+                                INTERVAL_AUTO_UPDATE);
         }
 
-        private synchronized void ensureTargetLockMonitor() {
-                if (!Config.ENABLE_TARGET_LOCK_ASSIST) {
-                        return;
-                }
-                if (_targetLockId == 0) {
-                        return;
-                }
-                if (_targetLockFuture != null) {
-                        return;
-                }
-                int interval = Config.TARGET_LOCK_ASSIST_INTERVAL;
-                if (interval <= 0) {
-                        interval = 200;
-                }
-                interval = Math.max(50, interval);
-                _targetLockFuture = GeneralThreadPool.getInstance()
-                                .pcScheduleAtFixedRate(new L1TargetLockMonitor(getId()), 0L, interval);
-        }
-
-        private synchronized void cancelTargetLockMonitor() {
-                if (_targetLockFuture != null) {
-                        _targetLockFuture.cancel(true);
-                        _targetLockFuture = null;
-                }
-        }
-
-        public void setTargetLock(L1Character target) {
-                if (target == null) {
-                        clearTargetLock();
-                        return;
-                }
-                int targetId = target.getId();
-                if (_targetLockId != targetId) {
-                        _targetLockAssistActive = false;
-                }
-                _targetLockId = targetId;
-                ensureTargetLockMonitor();
-        }
-
-        public void clearTargetLock() {
-                if (_targetLockId == 0 && _targetLockIndicatorTargetId == 0 && _targetLockFuture == null) {
-                        _targetLockAssistActive = false;
-                        return;
-                }
-                _targetLockAssistActive = false;
-                clearTargetLockIndicator();
-                _targetLockId = 0;
-                cancelTargetLockMonitor();
-        }
-
-        public boolean hasTargetLock() {
-                return _targetLockId != 0;
-        }
-
-        public L1Character getTargetLockTarget() {
-int targetId = _targetLockId;
-if (targetId == 0) {
-return null;
-}
-L1Object obj = L1World.getInstance().findObject(targetId);
-if (!(obj instanceof L1Character)) {
-clearTargetLock();
-return null;
-}
-return (L1Character) obj;
-}
-
-        public synchronized void startTargetLockAssist() {
-                if (!Config.ENABLE_TARGET_LOCK_ASSIST) {
-                        return;
-                }
-                if (_targetLockId == 0) {
-                        return;
-                }
-                _targetLockAssistActive = true;
-                ensureTargetLockMonitor();
-                L1Character target = getTargetLockTarget();
-                if (target != null) {
-                        showTargetLockAssistIndicator(target);
-                }
-        }
-
-        public synchronized void stopTargetLockAssist() {
-                _targetLockAssistActive = false;
-                revertTargetLockIndicatorToIdle();
-                if (_targetLockId == 0) {
-                        cancelTargetLockMonitor();
-                }
-        }
-
-        public void showTargetLockSelectionIndicator(L1Character target) {
-                updateTargetLockIndicator(target, TargetLockIndicatorColor.TEAL);
-        }
-
-        public void showTargetLockAssistIndicator(L1Character target) {
-                updateTargetLockIndicator(target, TargetLockIndicatorColor.PURPLE);
-        }
-
-        private void revertTargetLockIndicatorToIdle() {
-                if (!Config.ENABLE_TARGET_LOCK_ASSIST) {
-                        clearTargetLockIndicator();
-                        return;
-                }
-                L1Character target = getTargetLockTarget();
-                if (target == null) {
-                        clearTargetLockIndicator();
-                        return;
-                }
-                updateTargetLockIndicator(target, TargetLockIndicatorColor.TEAL);
-        }
-
-        private synchronized void updateTargetLockIndicator(L1Character target, TargetLockIndicatorColor color) {
-                if (!Config.ENABLE_TARGET_LOCK_ASSIST) {
-                        return;
-                }
-                if (target == null || target.isDead() || target.getMapId() != getMapId()) {
-                        clearTargetLockIndicator();
-                        return;
-                }
-
-                int targetId = target.getId();
-                int targetX = target.getX();
-                int targetY = target.getY();
-                boolean targetChanged = _targetLockIndicatorTargetId != 0 && _targetLockIndicatorTargetId != targetId;
-                boolean positionChanged = _targetLockIndicatorX != targetX || _targetLockIndicatorY != targetY;
-                boolean colorChanged = _targetLockIndicatorColor != color;
-                long now = System.currentTimeMillis();
-                boolean needsRefresh = (now - _targetLockIndicatorLastBroadcastMillis) >= TARGET_LOCK_INDICATOR_REFRESH_INTERVAL_MS;
-
-                if (targetChanged && _targetLockIndicatorTargetId != 0) {
-                        L1Character previousTarget = null;
-                        L1Object previousTargetObject = L1World.getInstance().findObject(_targetLockIndicatorTargetId);
-                        if (previousTargetObject instanceof L1Character) {
-                                previousTarget = (L1Character) previousTargetObject;
-                        }
-                        sendTargetLockIndicatorPacket(previousTarget, _targetLockIndicatorX, _targetLockIndicatorY,
-                                        TARGET_LOCK_INDICATOR_CLEAR_GFX);
-                        _targetLockIndicatorLastBroadcastMillis = 0L;
-                        needsRefresh = true;
-                }
-
-                if (!targetChanged && !positionChanged && !colorChanged && !needsRefresh) {
-                        return;
-                }
-
-                int gfxId = color == TargetLockIndicatorColor.PURPLE ? TARGET_LOCK_INDICATOR_PURPLE_GFX
-                                : TARGET_LOCK_INDICATOR_TEAL_GFX;
-                sendTargetLockIndicatorPacket(target, targetX, targetY, gfxId);
-
-                _targetLockIndicatorTargetId = targetId;
-                _targetLockIndicatorX = targetX;
-                _targetLockIndicatorY = targetY;
-                _targetLockIndicatorMapId = target.getMapId();
-                _targetLockIndicatorColor = color;
-                _targetLockIndicatorLastBroadcastMillis = now;
-        }
-
-        private synchronized void clearTargetLockIndicator() {
-                if (_targetLockIndicatorTargetId == 0 && _targetLockIndicatorColor == TargetLockIndicatorColor.NONE) {
-                        return;
-                }
-                L1Character previousTarget = null;
-                if (_targetLockIndicatorTargetId != 0) {
-                        L1Object previousTargetObject = L1World.getInstance().findObject(_targetLockIndicatorTargetId);
-                        if (previousTargetObject instanceof L1Character) {
-                                previousTarget = (L1Character) previousTargetObject;
-                        }
-                }
-                sendTargetLockIndicatorPacket(previousTarget, _targetLockIndicatorX, _targetLockIndicatorY,
-                                TARGET_LOCK_INDICATOR_CLEAR_GFX);
-                _targetLockIndicatorTargetId = 0;
-                _targetLockIndicatorColor = TargetLockIndicatorColor.NONE;
-                _targetLockIndicatorX = 0;
-                _targetLockIndicatorY = 0;
-                _targetLockIndicatorMapId = 0;
-                _targetLockIndicatorLastBroadcastMillis = 0L;
-        }
-
-        private void sendTargetLockIndicatorPacket(L1Character broadcastTarget, int x, int y, int gfxId) {
-                S_EffectLocation packet = new S_EffectLocation(x, y, gfxId);
-                sendPackets(packet);
-                broadcastPacket(packet);
-                if (broadcastTarget != null && broadcastTarget != this) {
-                        broadcastTarget.broadcastPacket(packet);
-                }
-        }
-
-        public void onTargetLockMonitorTick() {
-                if (!Config.ENABLE_TARGET_LOCK_ASSIST) {
-                        clearTargetLock();
-                        return;
-                }
-                L1Character target = getTargetLockTarget();
-                if (target == null) {
-                        clearTargetLock();
-                        return;
-                }
-                TargetLockIndicatorColor indicatorColor = _targetLockAssistActive ? TargetLockIndicatorColor.PURPLE
-                                : TargetLockIndicatorColor.TEAL;
-                updateTargetLockIndicator(target, indicatorColor);
-
-                if (isGhost() || isDead() || isTeleport() || isInvisble() || isInvisDelay()) {
-                        stopTargetLockAssist();
-                        return;
-                }
-                if (target.isDead() || target.getMapId() != getMapId()) {
-                        clearTargetLock();
-                        return;
-                }
-                double distance = getLocation().getLineDistance(target.getLocation());
-                if (distance > 20D) {
-                        clearTargetLock();
-                        return;
-                }
-
-                if (!_targetLockAssistActive) {
-                        return;
-                }
-
-                if (getInventory().getWeight240() >= 197) {
-                        sendPackets(new S_ServerMessage(110));
-                        stopTargetLockAssist();
-                        return;
-                }
-                int range = getTargetLockRange();
-                if (!isAttackPosition(target.getX(), target.getY(), range)) {
-                        updateTargetLockIndicator(target, TargetLockIndicatorColor.TEAL);
-                        if (!moveTowardsTarget(target)) {
-                                stopTargetLockAssist();
-                        }
-                        return;
-                }
-                if (Config.CHECK_ATTACK_INTERVAL) {
-                        int result = getAcceleratorChecker().checkInterval(AcceleratorChecker.ACT_TYPE.ATTACK);
-                        if (result == AcceleratorChecker.R_LIMITEXCEEDED) {
-                                updateTargetLockIndicator(target, TargetLockIndicatorColor.TEAL);
-                                return;
-                        }
-                }
-                if (hasSkillEffect(ABSOLUTE_BARRIER)) {
-                        killSkillEffectTimer(ABSOLUTE_BARRIER);
-                        startHpRegeneration();
-                        startMpRegeneration();
-                        startMpRegenerationByDoll();
-                }
-                killSkillEffectTimer(MEDITATION);
-                delInvis();
-                setRegenState(REGENSTATE_ATTACK);
-                setHeading(targetDirection(target.getX(), target.getY()));
-                showTargetLockAssistIndicator(target);
-                target.onAction(this);
-        }
-
-private int getTargetLockRange() {
-L1ItemInstance weapon = getWeapon();
-if (weapon != null && weapon.getItem() != null) {
-int range = weapon.getItem().getRange();
-if (range > 0) {
-return range;
-}
-}
-return 1;
-}
-
-private boolean moveTowardsTarget(L1Character target) {
-int dir = targetDirection(target.getX(), target.getY());
-int newX = getX() + TARGET_LOCK_MOVE_X[dir];
-int newY = getY() + TARGET_LOCK_MOVE_Y[dir];
-L1Map map = getMap();
-if (map == null) {
-return false;
-}
-map.setPassable(getLocation(), true);
-if (!map.isPassable(newX, newY)) {
-map.setPassable(getLocation(), false);
-return false;
-}
-setHeading(dir);
-getLocation().set(newX, newY);
-setRegenState(REGENSTATE_MOVE);
-S_MoveCharPacket movePacket = new S_MoveCharPacket(this);
-sendPackets(movePacket);
-broadcastPacket(movePacket);
-map.setPassable(getLocation(), false);
-return true;
-}
-
-	public void stopHpRegeneration() {
+        public void stopHpRegeneration() {
 		if (_hpRegenActive) {
 			try {
 				_hpRegenFuture.cancel(true);
@@ -5310,5 +5004,325 @@ return true;
 	public void addMonsterKill(int i) {
 		_monsterKill += i;
 		sendPackets(new S_OwnCharStatus(this));
-	}
+        }
+
+        public void stopEtcMonitor() {
+                if (_autoUpdateFuture != null) {
+                        _autoUpdateFuture.cancel(true);
+                        _autoUpdateFuture = null;
+                }
+                if (_expMonitorFuture != null) {
+                        _expMonitorFuture.cancel(true);
+                        _expMonitorFuture = null;
+                }
+                if (_ghostFuture != null) {
+                        _ghostFuture.cancel(true);
+                        _ghostFuture = null;
+                }
+                if (_hellFuture != null) {
+                        _hellFuture.cancel(true);
+                        _hellFuture = null;
+                }
+                clearTargetLock();
+        }
+
+        private synchronized void ensureTargetLockMonitor() {
+                if (!Config.ENABLE_TARGET_LOCK_ASSIST) {
+                        return;
+                }
+                if (_targetLockId == 0 && _targetLockIndicatorTargetId == 0) {
+                        return;
+                }
+                if (_targetLockFuture != null) {
+                        return;
+                }
+                int interval = Config.TARGET_LOCK_ASSIST_INTERVAL;
+                if (interval <= 0) {
+                        interval = 200;
+                }
+                interval = Math.max(50, interval);
+                _targetLockFuture = GeneralThreadPool.getInstance()
+                                .pcScheduleAtFixedRate(new L1TargetLockMonitor(getId()), 0L, interval);
+        }
+
+        private synchronized void cancelTargetLockMonitor() {
+                if (_targetLockFuture != null) {
+                        _targetLockFuture.cancel(true);
+                        _targetLockFuture = null;
+                }
+        }
+
+        public void setTargetLock(L1Character target) {
+                if (target == null) {
+                        clearTargetLock();
+                        return;
+                }
+                int targetId = target.getId();
+                if (_targetLockId != targetId) {
+                        _targetLockAssistActive = false;
+                }
+                _targetLockId = targetId;
+                ensureTargetLockMonitor();
+        }
+
+        public synchronized void clearTargetLock() {
+                if (_targetLockId == 0 && _targetLockIndicatorTargetId == 0 && _targetLockFuture == null) {
+                        _targetLockAssistActive = false;
+                        return;
+                }
+                _targetLockAssistActive = false;
+                clearTargetLockIndicator();
+                _targetLockId = 0;
+                cancelTargetLockMonitor();
+        }
+
+        public boolean hasTargetLock() {
+                return _targetLockId != 0;
+        }
+
+        public L1Character getTargetLockTarget() {
+                int targetId = _targetLockId;
+                if (targetId == 0) {
+                        return null;
+                }
+                L1Object obj = L1World.getInstance().findObject(targetId);
+                if (!(obj instanceof L1Character)) {
+                        clearTargetLock();
+                        return null;
+                }
+                return (L1Character) obj;
+        }
+
+        public synchronized void startTargetLockAssist() {
+                if (!Config.ENABLE_TARGET_LOCK_ASSIST) {
+                        return;
+                }
+                if (_targetLockId == 0) {
+                        return;
+                }
+                ensureTargetLockMonitor();
+                _targetLockAssistActive = true;
+
+                L1Character target = getTargetLockTarget();
+                if (target == null) {
+                        clearTargetLock();
+                        return;
+                }
+                showTargetLockAssistIndicator(target);
+        }
+
+        public synchronized void stopTargetLockAssist() {
+                if (!_targetLockAssistActive && _targetLockFuture == null) {
+                        return;
+                }
+                _targetLockAssistActive = false;
+                revertTargetLockIndicatorToIdle();
+                if (_targetLockId == 0) {
+                        cancelTargetLockMonitor();
+                }
+        }
+
+        public void showTargetLockSelectionIndicator(L1Character target) {
+                updateTargetLockIndicator(target, TargetLockIndicatorColor.TEAL);
+                ensureTargetLockMonitor();
+        }
+
+        public void showTargetLockAssistIndicator(L1Character target) {
+                updateTargetLockIndicator(target, TargetLockIndicatorColor.PURPLE);
+        }
+
+        private void revertTargetLockIndicatorToIdle() {
+                if (!Config.ENABLE_TARGET_LOCK_ASSIST) {
+                        clearTargetLockIndicator();
+                        return;
+                }
+                L1Character target = getTargetLockTarget();
+                if (target == null) {
+                        clearTargetLockIndicator();
+                        return;
+                }
+                updateTargetLockIndicator(target, TargetLockIndicatorColor.TEAL);
+        }
+
+        private synchronized void updateTargetLockIndicator(L1Character target, TargetLockIndicatorColor color) {
+                if (!Config.ENABLE_TARGET_LOCK_ASSIST) {
+                        return;
+                }
+                if (target == null || target.isDead() || target.getMapId() != getMapId()) {
+                        clearTargetLockIndicator();
+                        return;
+                }
+
+                int targetId = target.getId();
+                int targetX = target.getX();
+                int targetY = target.getY();
+                boolean targetChanged = _targetLockIndicatorTargetId != 0 && _targetLockIndicatorTargetId != targetId;
+                boolean positionChanged = _targetLockIndicatorX != targetX || _targetLockIndicatorY != targetY;
+                boolean colorChanged = _targetLockIndicatorColor != color;
+                long now = System.currentTimeMillis();
+                boolean needsRefresh = (now - _targetLockIndicatorLastBroadcastMillis) >= TARGET_LOCK_INDICATOR_REFRESH_INTERVAL_MS;
+
+                if (targetChanged && _targetLockIndicatorTargetId != 0) {
+                        L1Character previousTarget = null;
+                        L1Object previousTargetObject = L1World.getInstance().findObject(_targetLockIndicatorTargetId);
+                        if (previousTargetObject instanceof L1Character) {
+                                previousTarget = (L1Character) previousTargetObject;
+                        }
+                        sendTargetLockIndicatorPacket(previousTarget, _targetLockIndicatorX, _targetLockIndicatorY,
+                                        TARGET_LOCK_INDICATOR_CLEAR_GFX);
+                        _targetLockIndicatorLastBroadcastMillis = 0L;
+                        needsRefresh = true;
+                }
+
+                if (!targetChanged && !positionChanged && !colorChanged && !needsRefresh) {
+                        return;
+                }
+
+                int gfxId = color == TargetLockIndicatorColor.PURPLE ? TARGET_LOCK_INDICATOR_PURPLE_GFX
+                                : TARGET_LOCK_INDICATOR_TEAL_GFX;
+                sendTargetLockIndicatorPacket(target, targetX, targetY, gfxId);
+
+                _targetLockIndicatorTargetId = targetId;
+                _targetLockIndicatorX = targetX;
+                _targetLockIndicatorY = targetY;
+                _targetLockIndicatorMapId = target.getMapId();
+                _targetLockIndicatorColor = color;
+                _targetLockIndicatorLastBroadcastMillis = now;
+        }
+
+        private synchronized void clearTargetLockIndicator() {
+                if (_targetLockIndicatorTargetId == 0 && _targetLockIndicatorColor == TargetLockIndicatorColor.NONE) {
+                        return;
+                }
+                L1Character previousTarget = null;
+                if (_targetLockIndicatorTargetId != 0) {
+                        L1Object previousTargetObject = L1World.getInstance().findObject(_targetLockIndicatorTargetId);
+                        if (previousTargetObject instanceof L1Character) {
+                                previousTarget = (L1Character) previousTargetObject;
+                        }
+                }
+                sendTargetLockIndicatorPacket(previousTarget, _targetLockIndicatorX, _targetLockIndicatorY,
+                                TARGET_LOCK_INDICATOR_CLEAR_GFX);
+                _targetLockIndicatorTargetId = 0;
+                _targetLockIndicatorColor = TargetLockIndicatorColor.NONE;
+                _targetLockIndicatorX = 0;
+                _targetLockIndicatorY = 0;
+                _targetLockIndicatorMapId = 0;
+                _targetLockIndicatorLastBroadcastMillis = 0L;
+        }
+
+        private void sendTargetLockIndicatorPacket(L1Character broadcastTarget, int x, int y, int gfxId) {
+                S_EffectLocation packet = new S_EffectLocation(x, y, gfxId);
+                sendPackets(packet);
+                broadcastPacket(packet);
+                if (broadcastTarget != null && broadcastTarget != this) {
+                        broadcastTarget.broadcastPacket(packet);
+                }
+        }
+
+        public void onTargetLockMonitorTick() {
+                if (!Config.ENABLE_TARGET_LOCK_ASSIST) {
+                        clearTargetLock();
+                        return;
+                }
+                L1Character target = getTargetLockTarget();
+                if (target == null) {
+                        clearTargetLock();
+                        return;
+                }
+
+                TargetLockIndicatorColor indicatorColor = _targetLockAssistActive ? TargetLockIndicatorColor.PURPLE
+                                : TargetLockIndicatorColor.TEAL;
+                updateTargetLockIndicator(target, indicatorColor);
+
+                if (!_targetLockAssistActive) {
+                        return;
+                }
+
+                if (isGhost() || isDead() || isTeleport() || isInvisble() || isInvisDelay()) {
+                        stopTargetLockAssist();
+                        return;
+                }
+
+                if (getInventory().getWeight240() >= 197) {
+                        sendPackets(new S_ServerMessage(110));
+                        stopTargetLockAssist();
+                        return;
+                }
+
+                if (target.isDead() || target.getMapId() != getMapId()) {
+                        clearTargetLock();
+                        return;
+                }
+
+                double distance = getLocation().getLineDistance(target.getLocation());
+                if (distance > 20D) {
+                        clearTargetLock();
+                        return;
+                }
+
+                int range = getTargetLockRange();
+                if (!isAttackPosition(target.getX(), target.getY(), range)) {
+                        updateTargetLockIndicator(target, TargetLockIndicatorColor.TEAL);
+                        if (!moveTowardsTarget(target)) {
+                                stopTargetLockAssist();
+                        }
+                        return;
+                }
+
+                if (Config.CHECK_ATTACK_INTERVAL) {
+                        int result = getAcceleratorChecker().checkInterval(AcceleratorChecker.ACT_TYPE.ATTACK);
+                        if (result == AcceleratorChecker.R_LIMITEXCEEDED) {
+                                updateTargetLockIndicator(target, TargetLockIndicatorColor.TEAL);
+                                return;
+                        }
+                }
+
+                if (hasSkillEffect(ABSOLUTE_BARRIER)) {
+                        killSkillEffectTimer(ABSOLUTE_BARRIER);
+                        startHpRegeneration();
+                        startMpRegeneration();
+                        startMpRegenerationByDoll();
+                }
+                killSkillEffectTimer(MEDITATION);
+                delInvis();
+                setRegenState(REGENSTATE_ATTACK);
+                setHeading(targetDirection(target.getX(), target.getY()));
+                showTargetLockAssistIndicator(target);
+                target.onAction(this);
+        }
+
+        private int getTargetLockRange() {
+                L1ItemInstance weapon = getWeapon();
+                if (weapon != null && weapon.getItem() != null) {
+                        int range = weapon.getItem().getRange();
+                        if (range > 0) {
+                                return range;
+                        }
+                }
+                return 1;
+        }
+
+        private boolean moveTowardsTarget(L1Character target) {
+                int dir = targetDirection(target.getX(), target.getY());
+                int newX = getX() + TARGET_LOCK_MOVE_X[dir];
+                int newY = getY() + TARGET_LOCK_MOVE_Y[dir];
+                L1Map map = getMap();
+                if (map == null) {
+                        return false;
+                }
+                map.setPassable(getLocation(), true);
+                if (!map.isPassable(newX, newY)) {
+                        map.setPassable(getLocation(), false);
+                        return false;
+                }
+                setHeading(dir);
+                getLocation().set(newX, newY);
+                setRegenState(REGENSTATE_MOVE);
+                S_MoveCharPacket movePacket = new S_MoveCharPacket(this);
+                sendPackets(movePacket);
+                broadcastPacket(movePacket);
+                map.setPassable(getLocation(), false);
+                return true;
+        }
 }


### PR DESCRIPTION
## Summary
- ensure target lock assist highlights broadcast correctly, follow color changes, and clean up on logout, death, or assist cancellation
- default TargetLockAssistEnabled to true in configuration so the feature is active out of the box

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1891078c88332819ccb01100f2ca7