### PR TITLE
Assign unique hunting assist marker opcode

### DIFF
--- a/src/l1j/server/server/encryptions/Opcodes.java
+++ b/src/l1j/server/server/encryptions/Opcodes.java
@@ -198,7 +198,7 @@ public class Opcodes {
 	public static final int S_OPCODE_SELECTLIST = 208;
         public static final int S_OPCODE_SELECTTARGET = 177;
         public static final int S_OPCODE_SERVERMSG = 14;
-        public static final int S_OPCODE_HUNTINGASSISTMARKER = 254;
+        public static final int S_OPCODE_HUNTINGASSISTMARKER = 251;
 	public static final int S_OPCODE_SERVERSTAT = 55; // can't find
 	public static final int S_OPCODE_SERVERVERSION = 151;
 	public static final int S_OPCODE_SHOWHTML = 119;


### PR DESCRIPTION
## Summary
- assign a distinct packet id to the hunting assist marker to prevent collisions with shop packets

## Testing
- Not run (client compatibility testing is not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e1c75d827483328e973f450e8b32d3