### PR TITLE
Align skill id mapping with 9-column client grid

### DIFF
--- a/src/l1j/server/server/clientpackets/C_UseSkill.java
+++ b/src/l1j/server/server/clientpackets/C_UseSkill.java
@@ -53,7 +53,10 @@ public class C_UseSkill extends ClientBasePacket {
 		super(abyte0);
 		int row = readC();
 		int column = readC();
-		int skillId = (row * 8) + column + 1;
+                // The client skill window now renders 9 columns instead of 8.
+                // Keep the server-side mapping in sync so that the clicked slot
+                // resolves to the expected skill id (e.g. Counter Barrier).
+                int skillId = (row * 9) + column + 1;
 		String charName = null;
 		String message = null;
 		int targetId = 0;


### PR DESCRIPTION
## Summary
- update C_UseSkill skill slot mapping to match the client's 9-column layout
- document the change so Counter Barrier resolves to the correct skill id

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2631a15688332b1f625c92d12630e